### PR TITLE
Add functional test for meshcop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ matrix:
   include:
     - env: BUILD_TARGET="pretty-check"
       os: linux
-    - env: BUILD_TARGET="posix-check"
+    - env: BUILD_TARGET="posix-check" VERBOSE=1
       os: linux
       compiler: gcc

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -42,17 +42,14 @@ linux)
     # This is for configuring wpantund
     sudo apt-get install autoconf-archive
 
-    # mDNS
-    sudo apt-get install libavahi-core-dev
-
-    # Doxygen
+    # For libcoap generate doc
     sudo apt-get install doxygen
 
     # For libcoap to generate .sym and .map
     sudo apt-get install ctags
 
-    # Boost
-    sudo apt-get install libboost-dev libboost-filesystem-dev libboost-system-dev
+    # Dependencies
+    sudo apt-get install libboost-dev libboost-filesystem-dev libboost-system-dev libavahi-core-dev
 
     # npm bower
     curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
@@ -60,6 +57,9 @@ linux)
     sudo apt-get install -y nodejs
 
     sudo npm -g install bower
+
+    # For functional test
+    sudo apt-get install expect
 
     # Uncrustify
     [ $BUILD_TARGET != pretty-check ] || (cd /tmp &&
@@ -81,6 +81,9 @@ linux)
         ./autogen.sh &&
         ./configure --prefix=/usr &&
         make install DESTDIR=../cpputest) || die
+
+    # Enable IPv6
+    [ $BUILD_TARGET != posix-check ] || (echo 0 | sudo tee /proc/sys/net/ipv6/conf/all/disable_ipv6) || die
     ;;
 *)
     die

--- a/bootstrap
+++ b/bootstrap
@@ -32,6 +32,7 @@
 #      nlbuild-autotools repository for this project.
 #
 
+(cd third_party/libcoap && patch -p1 < patch/0001-remove-generated-files-and-fix-separate-response.patch)
 (cd third_party/libcoap/repo && ./autogen.sh)
 
 # Set this to the relative location of nlbuild-autotools to this script

--- a/configure.ac
+++ b/configure.ac
@@ -398,6 +398,7 @@ src/web/Makefile
 src/common/Makefile
 src/utils/Makefile
 tests/Makefile
+tests/meshcop/Makefile
 tests/unit/Makefile
 tools/Makefile
 doc/Makefile

--- a/src/agent/Makefile.am
+++ b/src/agent/Makefile.am
@@ -67,14 +67,14 @@ libotbr_agent_la_LDFLAGS = \
     $(NULL)
 
 libotbr_agent_la_CPPFLAGS                                                  = \
+    -DMBEDTLS_CONFIG_FILE='<config-thread.h>'                                \
+    -I$(top_srcdir)/third_party/mbedtls/repo/configs                         \
+    -I$(top_srcdir)/third_party/mbedtls/repo/include                         \
     -I$(top_builddir)/third_party/libcoap/repo                               \
     -I$(top_srcdir)/src                                                      \
     -I$(top_srcdir)/third_party/libcoap/repo                                 \
     -I$(top_srcdir)/third_party/libcoap/repo/include                         \
     -I$(top_srcdir)/third_party/wpantund/repo/src                            \
-    -I$(top_srcdir)/third_party/mbedtls/repo/configs                         \
-    -I$(top_srcdir)/third_party/mbedtls/repo/include                         \
-    -DMBEDTLS_CONFIG_FILE='<config-thread.h>'                                \
     -I$(top_builddir)/third_party/wpantund/repo/src                          \
     -I$(top_srcdir)/third_party/wpantund/repo/src                            \
     -I$(top_srcdir)/third_party/wpantund/repo/src/ipc-dbus                   \

--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -69,7 +69,8 @@ enum
  */
 enum
 {
-    kCoapUdpPort    = 61631, ///< Thread management UDP port.
+    kCoapUdpPort        = 61631, ///< Thread management UDP port.
+    kBorderAgentUdpPort = 49191, ///< Thread commissioning port.
 };
 
 /**
@@ -213,7 +214,7 @@ BorderAgent::BorderAgent(const char *aInterfaceName) :
     mNcpController(Ncp::Controller::Create(aInterfaceName, HandlePSKcChanged, FeedCoap, this)),
     mCoap(Coap::Agent::Create(SendCoap, kCoapResources, this)),
     mCoaps(Coap::Agent::Create(SendCoaps, kCoapsResources, this)),
-    mDtlsServer(Dtls::Server::Create(HandleDtlsSessionState, this))
+    mDtlsServer(Dtls::Server::Create(kBorderAgentUdpPort, HandleDtlsSessionState, this))
 {
     int error = 0;
 
@@ -231,7 +232,7 @@ BorderAgent::BorderAgent(const char *aInterfaceName) :
         syslog(LOG_ERR, "failed to get PSKc");
         throw std::runtime_error("Failed to get PSKc");
     }
-    mDtlsServer->SetPSK(pskc);
+    mDtlsServer->SetPSK(pskc, kSizePSKc);
 
     const uint8_t *eui64 = mNcpController->GetEui64();
     if (eui64 == NULL)
@@ -325,7 +326,7 @@ void BorderAgent::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, c
 
 void BorderAgent::HandlePSKcChanged(const uint8_t *aPSKc, void *aContext)
 {
-    static_cast<BorderAgent *>(aContext)->mDtlsServer->SetPSK(aPSKc);
+    static_cast<BorderAgent *>(aContext)->mDtlsServer->SetPSK(aPSKc, kSizePSKc);
 }
 
 } // namespace BorderAgent

--- a/src/agent/border_agent.hpp
+++ b/src/agent/border_agent.hpp
@@ -97,6 +97,7 @@ private:
     void HandleDtlsSessionState(Dtls::Session &aSession, Dtls::Session::State aState);
 
     static void HandleRelayReceive(const Coap::Resource &aResource, const Coap::Message &aMessage,
+                                   Coap::Message &aResponse,
                                    const uint8_t *aIp6, uint16_t aPort, void *aContext)
     {
         static_cast<BorderAgent *>(aContext)->HandleRelayReceive(aMessage, aIp6, aPort);
@@ -104,6 +105,7 @@ private:
     void HandleRelayReceive(const Coap::Message &aMessage, const uint8_t *aIp6, uint16_t aPort);
 
     static void HandleRelayTransmit(const Coap::Resource &aResource, const Coap::Message &aMessage,
+                                    Coap::Message &aResponse,
                                     const uint8_t *aIp6, uint16_t aPort, void *aContext)
     {
         static_cast<BorderAgent *>(aContext)->HandleRelayTransmit(aMessage, aIp6, aPort);
@@ -111,6 +113,7 @@ private:
     void HandleRelayTransmit(const Coap::Message &aMessage, const uint8_t *aIp6, uint16_t aPort);
 
     static void ForwardCommissionerRequest(const Coap::Resource &aResource, const Coap::Message &aMessage,
+                                           Coap::Message &aResponse,
                                            const uint8_t *aIp6, uint16_t aPort, void *aContext)
     {
         static_cast<BorderAgent *>(aContext)->ForwardCommissionerRequest(aResource, aMessage, aIp6, aPort);

--- a/src/agent/coap.hpp
+++ b/src/agent/coap.hpp
@@ -100,6 +100,7 @@ public:
      *
      */
     virtual Code GetCode(void) const = 0;
+    virtual void SetCode(Code aCode) = 0;
 
     /**
      * This method returns the CoAP type of this message.
@@ -108,6 +109,7 @@ public:
      *
      */
     virtual Type GetType(void) const = 0;
+    virtual void SetType(Type aType) = 0;
 
     /**
      * This method returns the token of this message.
@@ -118,6 +120,7 @@ public:
      *
      */
     virtual const uint8_t *GetToken(uint8_t &aLength) const = 0;
+    virtual void SetToken(const uint8_t *aToken, uint8_t aLength) = 0;
 
     /**
      * This method sets the CoAP Uri Path of this message.
@@ -151,14 +154,16 @@ typedef struct Resource Resource;
 /**
  * This function pointer is called when a CoAP request received.
  *
- * @param[in]   aResource   A pointer to the resource requested.
- * @param[in]   aMessage    A pointer to the CoAP message.
- * @param[in]   aIp6        A pointer to the source Ipv6 address of this request.
+ * @param[in]   aResource   A reference to the resource requested.
+ * @param[in]   aRequest    A reference to the CoAP request message.
+ * @param[in]   aResponse   A reference to the CoAP response message.
+ * @param[in]   aIp6        A reference to the source Ipv6 address of this request.
  * @param[in]   aPort       Source UDP port of this request.
  * @param[in]   aContext    A pointer to application-specific context.
  *
  */
-typedef void (*RequestHandler)(const Resource &aResource, const Message &aMessage, const uint8_t *aIp6,
+typedef void (*RequestHandler)(const Resource &aResource, const Message &aRequest, Message &aResponse,
+                               const uint8_t *aIp6,
                                uint16_t aPort,
                                void *aContext);
 

--- a/src/agent/coap_libcoap.hpp
+++ b/src/agent/coap_libcoap.hpp
@@ -78,10 +78,13 @@ public:
     virtual ~MessageLibcoap(void) {};
 
     Code GetCode(void) const;
+    void SetCode(Code aCode);
 
     Type GetType(void) const;
+    void SetType(Type aType);
 
     const uint8_t *GetToken(uint8_t &aLength) const;
+    void SetToken(const uint8_t *aToken, uint8_t aLength);
 
     void SetPath(const char *aPath);
 

--- a/src/agent/main.cpp
+++ b/src/agent/main.cpp
@@ -66,7 +66,7 @@ int Mainloop(const char *aInterfaceName)
         if ((rval < 0) && (errno != EINTR))
         {
             rval = errno;
-            perror("select");
+            perror("select failed");
             break;
         }
 
@@ -110,11 +110,11 @@ int main(int argc, char *argv[])
     if (interfaceName == NULL)
     {
         interfaceName = kDefaultInterfaceName;
-        printf("interfaceName not specified, using default %s\n", interfaceName);
+        printf("Network interface not specified, using default %s\n", interfaceName);
     }
 
     openlog(kSyslogIdent, LOG_CONS | LOG_PID, LOG_USER);
-    syslog(LOG_INFO, "backbone router started on %s", interfaceName);
+    syslog(LOG_INFO, "border router agent started on %s", interfaceName);
 
     ret = Mainloop(interfaceName);
 

--- a/src/common/tlv.hpp
+++ b/src/common/tlv.hpp
@@ -59,6 +59,14 @@ public:
     }
 
     /**
+     * This method sets the Tlv type.
+     *
+     */
+    void SetType(uint8_t aType) {
+        mType = aType;
+    }
+
+    /**
      * This method returns the Tlv length.
      *
      * @returns The Tlv length.
@@ -66,6 +74,22 @@ public:
      */
     uint16_t GetLength(void) const {
         return (mLength != kLengthEscape ? mLength : ((&mLength)[1] << 8 | (&mLength)[2]));
+    }
+
+    /**
+     * This method sets the length.
+     */
+    void SetLength(uint16_t aLength) {
+        if (aLength >= kLengthEscape)
+        {
+            mLength = kLengthEscape;
+            (&mLength)[1] = (aLength >> 8);
+            (&mLength)[2] = (aLength & 0xff);
+        }
+        else
+        {
+            mLength = static_cast<uint8_t>(aLength);
+        }
     }
 
     /**
@@ -92,6 +116,43 @@ public:
     }
 
     /**
+     * This method returns the value as a uint8_t.
+     *
+     * @returns The uint8_t value.
+     *
+     */
+    uint8_t GetValueUInt8(void) const {
+        return *static_cast<const uint8_t *>(GetValue());
+    }
+
+    /**
+     * This method sets uint16_t as the value.
+     */
+    void SetValue(uint16_t aValue) {
+        SetLength(sizeof(aValue));
+        uint8_t *value = static_cast<uint8_t *>(GetValue());
+        value[0] = (aValue >> 8);
+        value[1] = (aValue & 0xff);
+    }
+
+    /**
+     * This method sets uint8_t as the value.
+     */
+    void SetValue(uint8_t aValue) {
+        SetLength(sizeof(aValue));
+        *static_cast<uint8_t *>(GetValue()) = aValue;
+    }
+
+    /**
+     * This method copies the value.
+     */
+    void SetValue(const void *aValue, uint16_t aLength)
+    {
+        SetLength(aLength);
+        memcpy(GetValue(), aValue, aLength);
+    }
+
+    /**
      * This method returns the pointer to the next Tlv.
      *
      * @returns A pointer to the next Tlv.
@@ -101,10 +162,41 @@ public:
         return reinterpret_cast<const Tlv *>(static_cast<const uint8_t *>(GetValue()) + GetLength());
     }
 
+    /**
+     * This method returns the pointer to the next Tlv.
+     *
+     * @returns A pointer to the next Tlv.
+     *
+     */
+    Tlv *GetNext(void) {
+        return reinterpret_cast<Tlv *>(static_cast<uint8_t *>(GetValue()) + GetLength());
+    }
+
 private:
+    void *GetValue(void) {
+        return reinterpret_cast<uint8_t *>(this) + sizeof(mType) +
+               (mLength != kLengthEscape ? sizeof(mLength) : (sizeof(uint16_t)  + sizeof(mLength)));
+    }
     uint8_t mType;
     uint8_t mLength;
 };
+
+namespace Meshcop {
+
+enum
+{
+    kState = 16,
+    kCommissionerId = 10,
+    kCommissionerSessionId = 11,
+    kJoinerDtlsEncapsulation = 17,
+    kSteeringData = 8,
+    kJoinerUdpPort = 18,
+    kJoinerIid = 19,
+    kJoinerRouterLocator = 20,
+    kJoinerRouterKek = 21,
+};
+
+} // namespace Meshcop
 
 } // namespace ot
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -28,6 +28,9 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
-SUBDIRS = unit
+SUBDIRS         = \
+    unit          \
+    meshcop       \
+    $(NULL)
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/tests/meshcop/Makefile.am
+++ b/tests/meshcop/Makefile.am
@@ -28,47 +28,44 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
-lib_LTLIBRARIES=libmbedtls.la
+noinst_PROGRAMS = commissioner
 
-libmbedtls_la_SOURCES                   = \
-    repo/library/aes.c                    \
-    repo/library/md.c                     \
-    repo/library/md_wrap.c                \
-    repo/library/memory_buffer_alloc.c    \
-    repo/library/platform.c               \
-    repo/library/sha256.c                 \
-    repo/library/bignum.c                 \
-    repo/library/ccm.c                    \
-    repo/library/cipher.c                 \
-    repo/library/cipher_wrap.c            \
-    repo/library/cmac.c                   \
-    repo/library/ctr_drbg.c               \
-    repo/library/debug.c                  \
-    repo/library/ecjpake.c                \
-    repo/library/ecp.c                    \
-    repo/library/ecp_curves.c             \
-    repo/library/entropy.c                \
-    repo/library/entropy_poll.c           \
-    repo/library/ssl_cookie.c             \
-    repo/library/ssl_ciphersuites.c       \
-    repo/library/ssl_cli.c                \
-    repo/library/ssl_srv.c                \
-    repo/library/ssl_ticket.c             \
-    repo/library/ssl_tls.c                \
-    repo/library/net_sockets.c            \
-    repo/library/timing.c                 \
+commissioner_SOURCES                                   = \
+    commissioner.cpp                                     \
     $(NULL)
 
-libmbedtls_la_CPPFLAGS                        = \
-    -I$(srcdir)/repo/include                    \
-    -I$(srcdir)/repo/configs                    \
-    -DMBEDTLS_CONFIG_FILE='<config-thread.h>'   \
-    -DMBEDTLS_DEBUG_C                           \
+commissioner_CPPFLAGS                                  = \
+    -DMBEDTLS_CONFIG_FILE='<config-thread.h>'            \
+    -I$(top_srcdir)/third_party/mbedtls/repo/configs     \
+    -I$(top_srcdir)/third_party/mbedtls/repo/include     \
+    -I$(top_srcdir)/src                                  \
+    -I$(top_srcdir)/src/agent                            \
+    -I$(top_srcdir)/src/web                              \
     $(NULL)
 
-noinst_HEADERS                      = \
-    repo/configs/config-thread.h      \
-    repo/include                      \
+commissioner_LDADD                                     = \
+    $(top_builddir)/src/agent/libotbr-agent.la           \
+    $(top_builddir)/src/utils/libutils.la                \
+    $(top_builddir)/src/web/libotbr-web.la               \
     $(NULL)
+
+commissioner_LDFLAGS                                   = \
+    -static                                              \
+    $(NULL)
+
+EXTRA_DIST                                             = \
+    meshcop                                              \
+    $(NULL)
+
+TESTS_ENVIRONMENT                                         = \
+    export                                                  \
+    MAKE=$(MAKE)                                            \
+    top_builddir='$(top_builddir)'                          \
+    top_srcdir='$(top_srcdir)'                              \
+    VERBOSE=1                                               \
+    LD_LIBRARY_PATH=$(top_builddir)/third_party/cppcms/repo \
+    ;
+
+TESTS = meshcop
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/tests/meshcop/commissioner.cpp
+++ b/tests/meshcop/commissioner.cpp
@@ -1,0 +1,815 @@
+/*
+ *    Copyright (c) 2017, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   The file implements the Thread commissioner for test.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <syslog.h>
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+#include <mbedtls/net_sockets.h>
+#include <mbedtls/debug.h>
+#include <mbedtls/ssl.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/ecjpake.h>
+#include <mbedtls/error.h>
+#include <mbedtls/certs.h>
+#include <mbedtls/timing.h>
+
+#include "agent/coap.hpp"
+#include "agent/dtls.hpp"
+#include "agent/uris.hpp"
+#include "common/tlv.hpp"
+#include "common/code_utils.hpp"
+#include "utils/hex.hpp"
+
+#define SERVER_PORT "49191"
+#define SERVER_NAME "localhost"
+#define SERVER_ADDR "127.0.0.1" /* forces IPv4 */
+
+#define READ_TIMEOUT_MS 1000
+#define MAX_RETRY       5
+
+#define MBEDTLS_DEBUG_C
+#define DEBUG_LEVEL 1
+
+#define SYSLOG_IDENT "otCommissioner"
+
+using namespace ot;
+using namespace ot::BorderAgent;
+
+const uint8_t kSeed[] = "Commissioner";
+const uint8_t kPSKd[] = "123456";
+const char    kCommissionerId[] = "OpenThread";
+const int     kCipherSuites[] = {
+    MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8,
+    0
+};
+
+const struct timeval kPollTimeout = {10, 0};
+
+/**
+ * Steering data for joiner 18b4300000000002 with password 123456
+ */
+const uint8_t kSteeringData[] = {
+    0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+};
+
+/**
+ * Constants
+ */
+enum
+{
+    kPortJoinerSession = 49192,
+    kSizeMaxPacket = 1500,
+};
+
+/**
+ * Commissioner State
+ */
+enum
+{
+    kStateInvalid,
+    kStateConnected,
+    kStateAccepted,
+    kStateReady,
+    kStateAuthenticated,
+    kStateFinalized,
+    kStateDone,
+    kStateError,
+};
+
+/**
+ * Commissioner TLV types
+ */
+enum
+{
+    kJoinerDtlsEncapsulation
+};
+
+/**
+ * Commissioner Context.
+ */
+struct Context
+{
+    Coap::Agent         *mCoap;
+    Dtls::Server        *mDtlsServer;
+    Dtls::Session       *mSession;
+
+    mbedtls_ssl_context *mSsl;
+    mbedtls_net_context *mNet;
+
+    int                  mSocket;
+
+    uint16_t             mToken;
+    uint16_t             mCommissionerSessionId;
+    uint8_t              mPSK[16];
+    uint8_t              mKek[32];
+
+    int                  mState;
+
+    uint16_t             mJoinerUdpPort;
+    uint8_t              mJoinerIid[8];
+    uint16_t             mJoinerRouterLocator;
+};
+
+void HandleRelayReceive(const Coap::Resource &aResource, const Coap::Message &aMessage,
+                        Coap::Message &aResponse,
+                        const uint8_t *aIp6, uint16_t aPort, void *aContext);
+
+void HandleJoinerFinalize(const Coap::Resource &aResource, const Coap::Message &aMessage,
+                          Coap::Message &aResponse,
+                          const uint8_t *aIp6, uint16_t aPort, void *aContext);
+
+const Coap::Resource kCoapResources[] =
+{
+    { OPENTHREAD_URI_RELAY_RX, HandleRelayReceive },
+    { OPENTHREAD_URI_JOINER_FINALIZE, HandleJoinerFinalize },
+    { 0, 0 },
+};
+
+inline uint16_t LengthOf(const void *aStart, const void *aEnd)
+{
+    return static_cast<const uint8_t *>(aEnd) - static_cast<const uint8_t *>(aStart);
+}
+
+void HandleJoinerFinalize(const Coap::Resource &aResource, const Coap::Message &aRequest,
+                          Coap::Message &aResponse,
+                          const uint8_t *aIp6, uint16_t aPort, void *aContext)
+{
+    Context &context = *static_cast<Context *>(aContext);
+    uint8_t  payload[10];
+    Tlv     *responseTlv = reinterpret_cast<Tlv *>(payload);
+
+    context.mState = kStateFinalized;
+    responseTlv->SetType(Meshcop::kState);
+    responseTlv->SetValue(static_cast<uint8_t>(1));
+    responseTlv = responseTlv->GetNext();
+
+    // Piggyback response
+    aResponse.SetCode(Coap::Message::kCoapResponseChanged);
+    aResponse.SetPayload(payload, LengthOf(payload, responseTlv));
+}
+
+void HandleRelayReceive(const Coap::Resource &aResource, const Coap::Message &aMessage,
+                        Coap::Message &aResponse,
+                        const uint8_t *aIp6, uint16_t aPort, void *aContext)
+{
+    int            ret = 0;
+    uint16_t       length;
+    Context       &context = *static_cast<Context *>(aContext);
+    const uint8_t *payload = aMessage.GetPayload(length);
+
+    for (const Tlv *requestTlv = reinterpret_cast<const Tlv *>(payload);
+         LengthOf(payload, requestTlv) < length;
+         requestTlv = requestTlv->GetNext())
+    {
+        switch (requestTlv->GetType())
+        {
+        case Meshcop::kJoinerDtlsEncapsulation:
+            struct sockaddr_in addr;
+            memset(&addr, 0, sizeof(addr));
+            addr.sin_family = AF_INET;
+            addr.sin_port = htons(kPortJoinerSession);
+
+            ret = sendto(context.mSocket, requestTlv->GetValue(), requestTlv->GetLength(),
+                         0, reinterpret_cast<const struct sockaddr *>(&addr), sizeof(addr));
+            VerifyOrExit(ret != -1, ret = errno);
+            break;
+
+        case Meshcop::kJoinerUdpPort:
+            context.mJoinerUdpPort = requestTlv->GetValueUInt16();
+            break;
+
+        case Meshcop::kJoinerIid:
+            memcpy(context.mJoinerIid, requestTlv->GetValue(), sizeof(context.mJoinerIid));
+            break;
+
+        case Meshcop::kJoinerRouterLocator:
+            context.mJoinerRouterLocator = requestTlv->GetValueUInt16();
+            break;
+
+        default:
+            break;
+        }
+    }
+
+exit:
+    return;
+}
+
+int SendRelayTransmit(Context &aContext)
+{
+    uint8_t payload[kSizeMaxPacket];
+    uint8_t dtlsEncapsulation[kSizeMaxPacket];
+    Tlv    *responseTlv = reinterpret_cast<Tlv *>(payload);
+
+    ssize_t ret = recvfrom(aContext.mSocket, dtlsEncapsulation, sizeof(dtlsEncapsulation), 0, NULL, NULL);
+
+    VerifyOrExit(ret > 0);
+
+    responseTlv->SetType(Meshcop::kJoinerDtlsEncapsulation);
+    responseTlv->SetValue(dtlsEncapsulation, static_cast<uint16_t>(ret));
+    responseTlv = responseTlv->GetNext();
+
+    responseTlv->SetType(Meshcop::kJoinerUdpPort);
+    responseTlv->SetValue(aContext.mJoinerUdpPort);
+    responseTlv = responseTlv->GetNext();
+
+    responseTlv->SetType(Meshcop::kJoinerIid);
+    responseTlv->SetValue(aContext.mJoinerIid, sizeof(aContext.mJoinerIid));
+    responseTlv = responseTlv->GetNext();
+
+    responseTlv->SetType(Meshcop::kJoinerRouterLocator);
+    responseTlv->SetValue(aContext.mJoinerRouterLocator);
+    responseTlv = responseTlv->GetNext();
+
+    if (aContext.mState == kStateFinalized)
+    {
+        responseTlv->SetType(Meshcop::kJoinerRouterKek);
+        responseTlv->SetValue(aContext.mKek, sizeof(aContext.mKek));
+        responseTlv = responseTlv->GetNext();
+    }
+
+    {
+        Coap::Message *message;
+        uint16_t       token = ++aContext.mToken;
+
+        message = aContext.mCoap->NewMessage(Coap::Message::kCoapTypeNonConfirmable, Coap::Message::kCoapRequestPost,
+                                             reinterpret_cast<const uint8_t *>(&token), sizeof(token));
+        message->SetPath("c/tx");
+        message->SetPayload(payload, LengthOf(payload, responseTlv));
+        aContext.mCoap->Send(*message, NULL, 0, NULL);
+        aContext.mCoap->FreeMessage(message);
+    }
+
+exit:
+    return ret;
+}
+
+static ssize_t SendCoap(const uint8_t *aBuffer, uint16_t aLength, const uint8_t *aIp6, uint16_t aPort,
+                        void *aContext)
+{
+    ssize_t  ret = 0;
+    Context &context = *static_cast<Context *>(aContext);
+
+    if (aPort == 0)
+    {
+        ret = mbedtls_ssl_write(context.mSsl, aBuffer, aLength);
+    }
+    else
+    {
+        if (context.mSession)
+        {
+            ret = context.mSession->Write(aBuffer, aLength);
+        }
+        else
+        {
+            ret = -1;
+        }
+    }
+
+    return ret;
+}
+
+static void my_debug(void *ctx, int level,
+                     const char *file, int line,
+                     const char *str)
+{
+    ((void) level);
+
+    fprintf((FILE *) ctx, "%s:%04d: %s", file, line, str);
+    fflush((FILE *) ctx);
+}
+
+int export_keys(void *aContext, const unsigned char *aMasterSecret, const unsigned char *aKeyBlock,
+                size_t aMacLength, size_t aKeyLength, size_t aIvLength)
+{
+    return 0;
+}
+
+void HandleCommissionerPetition(const Coap::Message &aMessage, void *aContext)
+{
+    uint16_t       length;
+    const Tlv     *tlv;
+    const uint8_t *payload;
+    Context       &context = *static_cast<Context *>(aContext);
+
+    payload = aMessage.GetPayload(length);
+    tlv = reinterpret_cast<const Tlv *>(payload);
+
+    while (LengthOf(payload, tlv) < length)
+    {
+        switch (tlv->GetType())
+        {
+        case Meshcop::kState:
+            if (tlv->GetValueUInt8())
+            {
+                context.mState = kStateAccepted;
+            }
+            break;
+
+        case Meshcop::kCommissionerSessionId:
+            context.mCommissionerSessionId = tlv->GetValueUInt16();
+            break;
+
+        default:
+            break;
+        }
+        tlv = tlv->GetNext();
+    }
+}
+
+int CommissionerPetition(Context &aContext)
+{
+    int     ret;
+    uint8_t buffer[kSizeMaxPacket];
+    Tlv    *tlv = reinterpret_cast<Tlv *>(buffer);
+
+    Coap::Message *message;
+    uint16_t       token = ++aContext.mToken;
+
+    token = htons(token);
+    message = aContext.mCoap->NewMessage(Coap::Message::kCoapTypeConfirmable, Coap::Message::kCoapRequestPost,
+                                         reinterpret_cast<const uint8_t *>(&token), sizeof(token));
+    tlv->SetType(Meshcop::kCommissionerId);
+    tlv->SetValue(kCommissionerId, sizeof(kCommissionerId) - 1);
+    tlv = tlv->GetNext();
+
+    message->SetPath("c/cp");
+    message->SetPayload(buffer, LengthOf(buffer, tlv));
+    aContext.mCoap->Send(*message, NULL, 0, HandleCommissionerPetition);
+    aContext.mCoap->FreeMessage(message);
+
+    do
+    {
+        ret = mbedtls_ssl_read(aContext.mSsl, buffer, sizeof(buffer));
+        if (ret > 0)
+        {
+            aContext.mCoap->Input(buffer, static_cast<uint16_t>(ret), NULL, 0);
+            switch (aContext.mState)
+            {
+            case kStateAccepted:
+                ret = 0;
+                break;
+            case kStateConnected:
+                ret = MBEDTLS_ERR_SSL_WANT_READ;
+                break;
+            default:
+                ret = -1;
+                break;
+            }
+        }
+    }
+    while (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE);
+
+
+    return ret;
+}
+
+void HandleCommissionerSetResponse(const Coap::Message &aMessage, void *aContext)
+{
+    uint16_t       length;
+    const Tlv     *tlv;
+    const uint8_t *payload;
+    Context       &context = *static_cast<Context *>(aContext);
+
+    payload = (aMessage.GetPayload(length));
+    tlv = reinterpret_cast<const Tlv *>(payload);
+
+    while (LengthOf(payload, tlv) < length)
+    {
+        switch (tlv->GetType())
+        {
+        case Meshcop::kState:
+            if (tlv->GetValueUInt8())
+            {
+                context.mState = kStateReady;
+            }
+            break;
+
+        case Meshcop::kCommissionerSessionId:
+            context.mCommissionerSessionId = tlv->GetValueUInt16();
+            break;
+
+        default:
+            break;
+        }
+        tlv = tlv->GetNext();
+    }
+}
+
+int CommissionerSet(Context &aContext)
+{
+    int      ret = 0;
+    uint16_t token = ++aContext.mToken;
+    uint8_t  buffer[kSizeMaxPacket];
+    Tlv     *tlv = reinterpret_cast<Tlv *>(buffer);
+
+    Coap::Message *message;
+
+    token = htons(token);
+    message = aContext.mCoap->NewMessage(Coap::Message::kCoapTypeConfirmable, Coap::Message::kCoapRequestPost,
+                                         reinterpret_cast<const uint8_t *>(&token), sizeof(token));
+
+    tlv->SetType(Meshcop::kCommissionerSessionId);
+    tlv->SetValue(aContext.mCommissionerSessionId);
+    tlv = tlv->GetNext();
+
+    tlv->SetType(Meshcop::kSteeringData);
+    tlv->SetValue(kSteeringData, sizeof(kSteeringData));
+    tlv = tlv->GetNext();
+
+    message->SetPath("c/cs");
+    message->SetPayload(buffer, LengthOf(buffer, tlv));
+    aContext.mCoap->Send(*message, NULL, 0, HandleCommissionerSetResponse);
+    aContext.mCoap->FreeMessage(message);
+
+    do
+    {
+        ret = mbedtls_ssl_read(aContext.mSsl, buffer, sizeof(buffer));
+        if (ret > 0)
+        {
+            aContext.mCoap->Input(buffer, static_cast<uint16_t>(ret), NULL, 0);
+            switch (aContext.mState)
+            {
+            case kStateReady:
+                ret = 0;
+                break;
+
+            case kStateAccepted:
+                ret = MBEDTLS_ERR_SSL_WANT_READ;
+                break;
+
+            default:
+                break;
+            }
+        }
+    }
+    while (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE);
+
+    return ret;
+}
+
+void HandleCommissionerKeepAlive(const Coap::Message &aMessage, void *aContext)
+{
+    uint16_t       length;
+    const Tlv     *tlv;
+    const uint8_t *payload;
+    Context       &context = *static_cast<Context *>(aContext);
+
+    payload = (aMessage.GetPayload(length));
+    tlv = reinterpret_cast<const Tlv *>(payload);
+
+    while (LengthOf(payload, tlv) < length)
+    {
+        switch (tlv->GetType())
+        {
+        case Meshcop::kState:
+            if (tlv->GetValueUInt8())
+            {
+                context.mState = kStateReady;
+            }
+            else
+            {
+                context.mState = kStateError;
+            }
+            break;
+
+        default:
+            break;
+        }
+        tlv = tlv->GetNext();
+    }
+}
+
+int CommissionerKeepAlive(Context &aContext)
+{
+    int     ret = 0;
+    uint8_t buffer[kSizeMaxPacket];
+    Tlv    *tlv = reinterpret_cast<Tlv *>(buffer);
+
+    Coap::Message *message;
+
+    aContext.mToken++;
+    message = aContext.mCoap->NewMessage(Coap::Message::kCoapTypeConfirmable, Coap::Message::kCoapRequestPost,
+                                         reinterpret_cast<const uint8_t *>(&aContext.mToken), sizeof(aContext.mToken));
+
+    tlv->SetType(Meshcop::kState);
+    tlv->SetValue(static_cast<uint8_t>(1));
+    tlv = tlv->GetNext();
+
+    tlv->SetType(Meshcop::kCommissionerSessionId);
+    tlv->SetValue(aContext.mCommissionerSessionId);
+    tlv = tlv->GetNext();
+
+    message->SetPath("c/ca");
+    message->SetPayload(buffer, LengthOf(buffer, tlv));
+    aContext.mCoap->Send(*message, NULL, 0, HandleCommissionerKeepAlive);
+    aContext.mCoap->FreeMessage(message);
+
+    do
+    {
+        ret = mbedtls_ssl_read(aContext.mSsl, buffer, sizeof(buffer));
+    }
+    while (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE);
+
+    if (ret > 0)
+    {
+        aContext.mCoap->Input(buffer, static_cast<uint16_t>(ret), NULL, 0);
+        if (aContext.mState == kStateAccepted)
+        {
+            ret = 0;
+        }
+        else
+        {
+            ret = -1;
+        }
+    }
+
+    return ret;
+}
+
+int CommissionerSessionProcess(Context &context)
+{
+    uint8_t buf[kSizeMaxPacket];
+    int     ret;
+
+    ret = mbedtls_ssl_read(context.mSsl, buf, sizeof(buf));
+    if (ret > 0)
+    {
+        context.mCoap->Input(buf, static_cast<uint16_t>(ret), NULL, 0);
+    }
+
+    return ret;
+}
+
+void FeedCoaps(const uint8_t *aBuffer, uint16_t aLength, void *aContext)
+{
+    Context &context = *static_cast<Context *>(aContext);
+
+    context.mCoap->Input(aBuffer, aLength, NULL, 1);
+}
+
+void HandleSessionChange(Dtls::Session &aSession, Dtls::Session::State aState, void *aContext)
+{
+    Context &context = *static_cast<Context *>(aContext);
+
+    switch (aState)
+    {
+    case Dtls::Session::kStateReady:
+        context.mState = kStateAuthenticated;
+        memcpy(context.mKek, aSession.GetKek(), sizeof(context.mKek));
+        aSession.SetDataHandler(FeedCoaps, aContext);
+        context.mSession = &aSession;
+        break;
+
+    case Dtls::Session::kStateClose:
+        context.mState = kStateDone;
+        break;
+
+    case Dtls::Session::kStateError:
+    case Dtls::Session::kStateEnd:
+        context.mSession = NULL;
+        break;
+    default:
+        break;
+    }
+}
+
+int CommissionerServe(Context &aContext)
+{
+    fd_set readFdSet;
+    fd_set writeFdSet;
+    fd_set errorFdSet;
+    int    ret = 0;
+
+    aContext.mSocket = socket(AF_INET, SOCK_DGRAM, 0);
+    VerifyOrExit(aContext.mSocket != -1, ret = errno);
+    aContext.mDtlsServer = Dtls::Server::Create(kPortJoinerSession, HandleSessionChange, &aContext);
+    aContext.mDtlsServer->SetPSK(kPSKd, strlen(reinterpret_cast<const char *>(kPSKd)));
+
+    while (aContext.mState != kStateDone && aContext.mState != kStateError)
+    {
+        struct timeval timeout = kPollTimeout;
+        int            maxFd = -1;
+
+        FD_ZERO(&readFdSet);
+        FD_ZERO(&writeFdSet);
+        FD_ZERO(&errorFdSet);
+
+        FD_SET(aContext.mNet->fd, &readFdSet);
+        FD_SET(aContext.mSocket, &readFdSet);
+        aContext.mDtlsServer->UpdateFdSet(readFdSet, writeFdSet, maxFd, timeout);
+        ret = select(maxFd + 1, &readFdSet, &writeFdSet, &errorFdSet, &timeout);
+        if ((ret < 0) && (errno != EINTR))
+        {
+            perror("select");
+            break;
+        }
+
+        if (FD_ISSET(aContext.mSocket, &readFdSet))
+        {
+            SendRelayTransmit(aContext);
+        }
+
+        if (FD_ISSET(aContext.mNet->fd, &readFdSet))
+        {
+            ret = CommissionerSessionProcess(aContext);
+            VerifyOrExit(ret > 0 || ret == MBEDTLS_ERR_SSL_TIMEOUT);
+        }
+
+        aContext.mDtlsServer->Process(readFdSet, writeFdSet);
+    }
+
+    aContext.mSession->Close();
+    Dtls::Server::Destroy(aContext.mDtlsServer);
+    close(aContext.mSocket);
+    if (aContext.mState == kStateDone)
+    {
+        ret = 0;
+    }
+    else
+    {
+        ret = -1;
+    }
+
+exit:
+
+    return ret;
+}
+
+int run(Context &context)
+{
+    int                          ret;
+    mbedtls_net_context          client_fd;
+    mbedtls_entropy_context      entropy;
+    mbedtls_ctr_drbg_context     ctr_drbg;
+    mbedtls_ssl_context          ssl;
+    mbedtls_ssl_config           conf;
+    mbedtls_timing_delay_context timer;
+
+    context.mSsl = &ssl;
+    context.mNet = &client_fd;
+#if defined(MBEDTLS_DEBUG_C)
+    mbedtls_debug_set_threshold(DEBUG_LEVEL);
+#endif
+
+    mbedtls_net_init(&client_fd);
+    mbedtls_ssl_init(&ssl);
+    mbedtls_ssl_config_init(&conf);
+    mbedtls_ctr_drbg_init(&ctr_drbg);
+
+    mbedtls_entropy_init(&entropy);
+    if ((ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy,
+                                     kSeed,
+                                     sizeof(kSeed))) != 0)
+    {
+        goto exit;
+    }
+
+    if ((ret = mbedtls_net_connect(&client_fd, SERVER_ADDR,
+                                   SERVER_PORT, MBEDTLS_NET_PROTO_UDP)) != 0)
+    {
+        goto exit;
+    }
+
+    if ((ret = mbedtls_ssl_config_defaults(&conf,
+                                           MBEDTLS_SSL_IS_CLIENT,
+                                           MBEDTLS_SSL_TRANSPORT_DATAGRAM,
+                                           MBEDTLS_SSL_PRESET_DEFAULT)) != 0)
+    {
+        goto exit;
+    }
+
+    mbedtls_ssl_conf_rng(&conf, mbedtls_ctr_drbg_random, &ctr_drbg);
+    mbedtls_ssl_conf_min_version(&conf, MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_3);
+    mbedtls_ssl_conf_max_version(&conf, MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_3);
+    mbedtls_ssl_conf_authmode(&conf, MBEDTLS_SSL_VERIFY_NONE);
+    mbedtls_ssl_conf_dbg(&conf, my_debug, stdout);
+    mbedtls_ssl_conf_ciphersuites(&conf, kCipherSuites);
+    mbedtls_ssl_conf_export_keys_cb(&conf, export_keys, NULL);
+    mbedtls_ssl_conf_handshake_timeout(&conf, 8000, 60000);
+
+    if ((ret = mbedtls_ssl_setup(&ssl, &conf)) != 0)
+    {
+        goto exit;
+    }
+
+    mbedtls_ssl_set_bio(&ssl, &client_fd,
+                        mbedtls_net_send, mbedtls_net_recv, mbedtls_net_recv_timeout);
+
+    mbedtls_ssl_set_timer_cb(&ssl, &timer, mbedtls_timing_set_delay,
+                             mbedtls_timing_get_delay);
+
+    mbedtls_ssl_set_hs_ecjpake_password(&ssl, context.mPSK, sizeof(context.mPSK));
+
+    do
+    {
+        ret = mbedtls_ssl_handshake(&ssl);
+    }
+    while (ret == MBEDTLS_ERR_SSL_WANT_READ ||
+           ret == MBEDTLS_ERR_SSL_WANT_WRITE);
+
+    if (ret != 0)
+    {
+        goto exit;
+    }
+
+    context.mState = kStateConnected;
+    context.mCoap = Coap::Agent::Create(SendCoap, kCoapResources, &context);
+    SuccessOrExit(ret = CommissionerPetition(context));
+    SuccessOrExit(ret = CommissionerSet(context));
+    SuccessOrExit(ret = CommissionerServe(context));
+
+    do
+        ret = mbedtls_ssl_close_notify(&ssl);
+    while (ret == MBEDTLS_ERR_SSL_WANT_WRITE);
+    ret = 0;
+
+exit:
+
+#ifdef MBEDTLS_ERROR_C
+    if (ret != 0)
+    {
+        char error_buf[100];
+        mbedtls_strerror(ret, error_buf, 100);
+        printf("Last error was: %d - %s\n\n", ret, error_buf);
+    }
+#endif
+
+    mbedtls_net_free(&client_fd);
+
+    mbedtls_ssl_free(&ssl);
+    mbedtls_ssl_config_free(&conf);
+    mbedtls_ctr_drbg_free(&ctr_drbg);
+    mbedtls_entropy_free(&entropy);
+
+    /* Shell can not handle large exit numbers -> 1 for errors */
+    if (ret < 0)
+    {
+        ret = -1;
+    }
+
+    return ret;
+}
+
+int main(int argc, char *argv[])
+{
+    int     ret = 0;
+    Context context;
+
+    if (argc != 2)
+    {
+        ExitNow(ret = 1);
+    }
+
+    ot::Utils::Hex2Bytes(argv[1], context.mPSK, sizeof(context.mPSK));
+
+    openlog(SYSLOG_IDENT, LOG_CONS | LOG_PID, LOG_USER);
+
+    ret = run(context);
+
+exit:
+    closelog();
+    return ret;
+}

--- a/tests/meshcop/meshcop
+++ b/tests/meshcop/meshcop
@@ -1,0 +1,157 @@
+#!/bin/sh
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+set -x
+
+STAGE_DIR=/tmp/test-otbr-stage
+BUILD_DIR=/tmp/test-otbr-build
+
+OT_PANID=0xface
+OT_XPANID=1122334455667788
+OT_PSKC=ee49a905637bbe2608dde3dc3576e188
+OT_JOINER_PASSWORD=123456
+OT_MASTER_KEY=00112233445566778899aabbccddeeff
+OT_CHANNEL=11
+OT_GATEWAY=fd11:22::
+
+TUN_NAME=wpan9
+
+test_setup()
+{
+    [ ! -d $STAGE_DIR ] || rm -rf $STAGE_DIR
+    [ ! -d $BUILD_DIR ] || rm -rf $BUILD_DIR
+    mkdir -p $BUILD_DIR
+    sudo cp $top_srcdir/src/border-agent/otbr-agent.conf /etc/dbus-1/system.d
+}
+
+build_wpantund()
+{
+    (cd $BUILD_DIR &&
+        git clone --depth 1 https://github.com/openthread/wpantund.git &&
+        cd wpantund &&
+        ./bootstrap.sh &&
+        ./configure --prefix=/usr --sysconf=/etc --disable-ncp-dummy --enable-static-link-ncp-plugin=spinel &&
+        make install DESTDIR=$STAGE_DIR &&
+        $STAGE_DIR/usr/sbin/wpantund --version &&
+        sudo cp $STAGE_DIR/etc/dbus-1/system.d/wpantund.conf /etc/dbus-1/system.d)
+}
+
+build_openthread()
+{
+    (cd $BUILD_DIR &&
+        git clone --depth 1 https://github.com/openthread/openthread.git &&
+        cd openthread &&
+        ./bootstrap &&
+        ./configure --prefix=/usr         \
+        --enable-border-agent-proxy       \
+        --enable-cli-app=ftd              \
+        --enable-ncp-app=ftd              \
+        --enable-joiner                   \
+        --with-examples=posix             \
+        --with-ncp-bus=uart               \
+        --with-platform-info=POSIX &&     \
+        make install DESTDIR=$STAGE_DIR)
+}
+
+leader_start()
+{
+    sudo sh -s <<EOF
+    cd /tmp
+    $STAGE_DIR/usr/sbin/wpantund -I $TUN_NAME -s "system:$STAGE_DIR/usr/bin/ot-ncp-ftd 1" &
+    echo 'Waiting for wpantund to fully start'
+    sleep 5
+
+    sudo $STAGE_DIR/usr/bin/wpanctl -I $TUN_NAME setprop Daemon:AutoAssociateAfterReset false
+    sudo $STAGE_DIR/usr/bin/wpanctl -I $TUN_NAME leave
+    sudo $STAGE_DIR/usr/bin/wpanctl -I $TUN_NAME setprop Network:PSKc --data $OT_PSKC
+    sudo $STAGE_DIR/usr/bin/wpanctl -I $TUN_NAME setprop Network:Key --data $OT_MASTER_KEY
+    sudo $STAGE_DIR/usr/bin/wpanctl -I $TUN_NAME setprop Network:PANID $OT_PANID
+    sudo $STAGE_DIR/usr/bin/wpanctl -I $TUN_NAME setprop Network:XPANID $OT_XPANID
+    sudo $STAGE_DIR/usr/bin/wpanctl -I $TUN_NAME form OpenThread -c $OT_CHANNEL
+    sudo $STAGE_DIR/usr/bin/wpanctl -I $TUN_NAME config-gateway -d $OT_GATEWAY
+EOF
+}
+
+ba_start()
+{
+    sudo $top_builddir/src/agent/otbr-agent -I $TUN_NAME &
+    echo 'Waiting for border agent start'
+    sleep 5
+}
+
+commissioner_start()
+{
+    ./commissioner $OT_PSKC &
+    echo 'Waitint for commissioner'
+    sleep 20
+}
+
+joiner_start()
+{
+    cd /tmp
+    expect -f- <<EOF
+spawn $STAGE_DIR/usr/bin/ot-cli-ftd 2
+send "ifconfig up\r\n"
+expect "Done"
+send "joiner start $OT_JOINER_PASSWORD\r\n"
+set timeout 20
+expect {
+  "Join success" {
+    send "exit\r\n"
+  }
+  timeout {
+    exit 1
+  }
+}
+EOF
+    cd -
+}
+
+test_teardown()
+{
+    echo 'clearing all'
+    sudo rm /etc/dbus-1/system.d/wpantund.conf
+    sudo rm /etc/dbus-1/system.d/otbr-agent.conf
+    sudo rm -rf $STAGE_DIR
+    sudo killall wpantund
+    sudo killall otbr-agent
+    sudo killall commissioner
+    wait
+}
+
+test_setup
+build_wpantund
+build_openthread
+leader_start
+ba_start
+commissioner_start
+joiner_start
+EXIT_CODE=$?
+test_teardown
+exit $EXIT_CODE

--- a/third_party/libcoap/Makefile.am
+++ b/third_party/libcoap/Makefile.am
@@ -34,9 +34,4 @@ DISTCHECK_CONFIGURE_FLAGS="--disable-examples"
 
 SUBDIRS=repo
 
-# Recover to prevent a dirty repo.
-
-dist-hook:
-	-git checkout repo
-
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/third_party/libcoap/patch/0001-remove-generated-files-and-fix-separate-response.patch
+++ b/third_party/libcoap/patch/0001-remove-generated-files-and-fix-separate-response.patch
@@ -1,0 +1,337 @@
+diff --git a/repo/Makefile.am b/repo/Makefile.am
+index 15e4881..fe467ec 100644
+--- a/repo/Makefile.am
++++ b/repo/Makefile.am
+@@ -174,6 +174,8 @@ distclean-local:
+ ## Ensure we have actual *.{map,sym} files if we create a release tarball.
+ dist-local: update-map-file
+ 
++$(lib_LTLIBRARIES): libcoap-$(LIBCOAP_API_VERSION).map libcoap-$(LIBCOAP_API_VERSION).sym
++
+ ## Finaly some phony targets, just to ensure those targets are always buildable
+ ## no matter if the user has created same called files.
+ .PHONY: update-map-file check_ctags
+diff --git a/repo/libcoap-1.map b/repo/libcoap-1.map
+deleted file mode 100644
+index 361f43c..0000000
+--- a/repo/libcoap-1.map
++++ /dev/null
+@@ -1,118 +0,0 @@
+-VER_1 {
+-global:
+-  coap_add_attr;
+-  coap_add_block;
+-  coap_add_data;
+-  coap_add_observer;
+-  coap_add_option;
+-  coap_add_option_later;
+-  coap_add_resource;
+-  coap_address_equals;
+-  coap_add_token;
+-  coap_adjust_basetime;
+-  coap_cancel_all_messages;
+-  coap_can_exit;
+-  coap_check_notify;
+-  coap_check_option;
+-  coap_clock_init;
+-  coap_clone_uri;
+-  coap_decode_var_bytes;
+-  coap_delete_all;
+-  coap_delete_all_resources;
+-  coap_delete_attr;
+-  coap_delete_node;
+-  coap_delete_observer;
+-  coap_delete_pdu;
+-  coap_delete_resource;
+-  coap_delete_string;
+-  coap_dispatch;
+-  coap_encode_var_bytes;
+-  coap_find_async;
+-  coap_find_attr;
+-  coap_find_observer;
+-  coap_find_transaction;
+-  coap_fls;
+-  coap_flsll;
+-  coap_free_async;
+-  coap_free_context;
+-  coap_free_endpoint;
+-  coap_free_packet;
+-  coap_free_type;
+-  coap_get_block;
+-  coap_get_data;
+-  coap_get_log_level;
+-  coap_get_resource_from_key;
+-  coap_handle_failed_notify;
+-  coap_handle_message;
+-  coap_hash_impl;
+-  coap_hash_path;
+-  coap_hash_request_uri;
+-  coap_insert_node;
+-  coap_is_mcast;
+-  coap_log_impl;
+-  coap_malloc_type;
+-  coap_memory_init;
+-  coap_network_read;
+-  coap_network_send;
+-  coap_new_context;
+-  coap_new_endpoint;
+-  coap_new_error_response;
+-  coap_new_node;
+-  coap_new_pdu;
+-  coap_new_string;
+-  coap_new_uri;
+-  coap_opt_block_num;
+-  coap_opt_delta;
+-  coap_opt_encode;
+-  coap_option_check_critical;
+-  coap_option_filter_get;
+-  coap_option_filter_set;
+-  coap_option_filter_unset;
+-  coap_option_iterator_init;
+-  coap_option_next;
+-  coap_opt_length;
+-  coap_opt_parse;
+-  coap_opt_setheader;
+-  coap_opt_size;
+-  coap_opt_value;
+-  coap_package_name;
+-  coap_package_version;
+-  coap_packet_copy_source;
+-  coap_packet_get_memmapped;
+-  coap_packet_populate_endpoint;
+-  coap_pdu_clear;
+-  coap_pdu_init;
+-  coap_pdu_parse;
+-  coap_peek_next;
+-  coap_pop_next;
+-  coap_print_addr;
+-  coap_print_link;
+-  coap_print_wellknown;
+-  coap_read;
+-  coap_register_async;
+-  coap_remove_async;
+-  coap_remove_from_queue;
+-  coap_resource_init;
+-  coap_response_phrase;
+-  coap_retransmit;
+-  coap_send;
+-  coap_send_ack;
+-  coap_send_confirmed;
+-  coap_send_error;
+-  coap_send_message_type;
+-  coap_set_log_level;
+-  coap_show_pdu;
+-  coap_split_path;
+-  coap_split_query;
+-  coap_split_uri;
+-  coap_subscription_init;
+-  coap_ticks;
+-  coap_ticks;
+-  coap_ticks_to_rt;
+-  coap_touch_observer;
+-  coap_transaction_id;
+-  coap_wellknown_response;
+-  coap_write_block_opt;
+-local:
+-  *;
+-};
+diff --git a/repo/libcoap-1.sym b/repo/libcoap-1.sym
+deleted file mode 100644
+index b910538..0000000
+--- a/repo/libcoap-1.sym
++++ /dev/null
+@@ -1,113 +0,0 @@
+-coap_add_attr
+-coap_add_block
+-coap_add_data
+-coap_add_observer
+-coap_add_option
+-coap_add_option_later
+-coap_add_resource
+-coap_address_equals
+-coap_add_token
+-coap_adjust_basetime
+-coap_cancel_all_messages
+-coap_can_exit
+-coap_check_notify
+-coap_check_option
+-coap_clock_init
+-coap_clone_uri
+-coap_decode_var_bytes
+-coap_delete_all
+-coap_delete_all_resources
+-coap_delete_attr
+-coap_delete_node
+-coap_delete_observer
+-coap_delete_pdu
+-coap_delete_resource
+-coap_delete_string
+-coap_dispatch
+-coap_encode_var_bytes
+-coap_find_async
+-coap_find_attr
+-coap_find_observer
+-coap_find_transaction
+-coap_fls
+-coap_flsll
+-coap_free_async
+-coap_free_context
+-coap_free_endpoint
+-coap_free_packet
+-coap_free_type
+-coap_get_block
+-coap_get_data
+-coap_get_log_level
+-coap_get_resource_from_key
+-coap_handle_failed_notify
+-coap_handle_message
+-coap_hash_impl
+-coap_hash_path
+-coap_hash_request_uri
+-coap_insert_node
+-coap_is_mcast
+-coap_log_impl
+-coap_malloc_type
+-coap_memory_init
+-coap_network_read
+-coap_network_send
+-coap_new_context
+-coap_new_endpoint
+-coap_new_error_response
+-coap_new_node
+-coap_new_pdu
+-coap_new_string
+-coap_new_uri
+-coap_opt_block_num
+-coap_opt_delta
+-coap_opt_encode
+-coap_option_check_critical
+-coap_option_filter_get
+-coap_option_filter_set
+-coap_option_filter_unset
+-coap_option_iterator_init
+-coap_option_next
+-coap_opt_length
+-coap_opt_parse
+-coap_opt_setheader
+-coap_opt_size
+-coap_opt_value
+-coap_package_name
+-coap_package_version
+-coap_packet_copy_source
+-coap_packet_get_memmapped
+-coap_packet_populate_endpoint
+-coap_pdu_clear
+-coap_pdu_init
+-coap_pdu_parse
+-coap_peek_next
+-coap_pop_next
+-coap_print_addr
+-coap_print_link
+-coap_print_wellknown
+-coap_read
+-coap_register_async
+-coap_remove_async
+-coap_remove_from_queue
+-coap_resource_init
+-coap_response_phrase
+-coap_retransmit
+-coap_send
+-coap_send_ack
+-coap_send_confirmed
+-coap_send_error
+-coap_send_message_type
+-coap_set_log_level
+-coap_show_pdu
+-coap_split_path
+-coap_split_query
+-coap_split_uri
+-coap_subscription_init
+-coap_ticks
+-coap_ticks
+-coap_ticks_to_rt
+-coap_touch_observer
+-coap_transaction_id
+-coap_wellknown_response
+-coap_write_block_opt
+diff --git a/repo/src/net.c b/repo/src/net.c
+index a549395..bbb6e7f 100644
+--- a/repo/src/net.c
++++ b/repo/src/net.c
+@@ -1535,12 +1535,58 @@ handle_request(coap_context_t *context, coap_queue_t *node) {
+   assert(response == NULL);
+ }
+ 
++static int
++coap_remove_separate_from_queue(coap_context_t *context, const coap_address_t *dst,
++			 const unsigned char *token, size_t token_length, coap_queue_t **sent) {
++  coap_queue_t *p, *q;
++  if (!context->sendqueue)
++    return 0;
++
++  if (coap_address_equals(dst, &context->sendqueue->remote) &&
++	    token_match(token, token_length,
++		              context->sendqueue->pdu->hdr->token,
++		              context->sendqueue->pdu->hdr->token_length) &&
++      context->sendqueue->retransmit_cnt > COAP_DEFAULT_MAX_RETRANSMIT) {
++    *sent = context->sendqueue;
++    context->sendqueue = context->sendqueue->next;
++    return 1;
++  }
++
++  p = context->sendqueue;
++  q = p->next;
++
++  /* when q is not NULL, it does not match (dst, token), so we can skip it */
++  while (q) {
++    if (coap_address_equals(dst, &context->sendqueue->remote) &&
++        token_match(token, token_length,
++                    context->sendqueue->pdu->hdr->token,
++                    context->sendqueue->pdu->hdr->token_length) &&
++        context->sendqueue->retransmit_cnt > COAP_DEFAULT_MAX_RETRANSMIT) {
++      p->next = q->next;
++      q->next = NULL;
++      *sent = q;
++      return 1;
++    } else {
++      p = q;
++      q = q->next;
++    }
++  }
++  return 0;
++}
++
+ static inline void
+ handle_response(coap_context_t *context, 
+ 		coap_queue_t *sent, coap_queue_t *rcvd) {
+ 
+   coap_send_ack(context, &rcvd->local_if, &rcvd->remote, rcvd->pdu);
+-  
++
++  /* Find separate response's request */
++  if (sent == NULL) {
++    coap_remove_separate_from_queue(context, &rcvd->remote,
++        rcvd->pdu->hdr->token,
++        rcvd->pdu->hdr->token_length, &sent);
++  }
++
+   /* In a lossy context, the ACK of a separate response may have
+    * been lost, so we need to stop retransmitting requests with the
+    * same token.
+@@ -1580,8 +1626,15 @@ coap_dispatch(coap_context_t *context, coap_queue_t *rcvd) {
+       /* find transaction in sendqueue to stop retransmission */
+       coap_remove_from_queue(&context->sendqueue, rcvd->id, &sent);
+ 
+-      if (rcvd->pdu->hdr->code == 0)
++      if (rcvd->pdu->hdr->code == 0) {
++        if (sent != NULL) {
++          sent->retransmit_cnt = COAP_DEFAULT_MAX_RETRANSMIT + 1;
++          sent->t = sent->timeout << COAP_DEFAULT_MAX_RETRANSMIT;
++          coap_insert_node(&context->sendqueue, sent);
++          sent = NULL;
++        }
+ 	goto cleanup;
++      }
+ 
+       /* if sent code was >= 64 the message might have been a 
+        * notification. Then, we must flag the observer to be alive


### PR DESCRIPTION
This PR,
* Adds functional test for meshcop(involves OpenThread, wpantund)
* Formalize the state machine of DTLS session.
* Fix timeout of DTLS.
* Support piggy-back response of CoAP API.

### Details

This test is based on the POSIX simulation of OpenThread and wpantund. The scenario is simple. Firstly, create an one node Thread network, thus the only node acts as Thread leader as well as Thread border router. Secondly, authenticate an external commissioner. At last, authenticate the joiner.

#### tests/meshcop/commissioner.cpp
Implements a simple commissioner app with fixed PSKd `123456`, steering data(for joiner whose EUI64 is 18b4300000000002) and commissioner id `OpenThread`. It connects to local border agent and petition to be the commissioner. Once success, it will authenticate the joiner.

#### OpenThread
Latest OpenThread is built to provide simulated Thread devices. One is in NCP mode and controlled by wpantund and act as the border router, the other is in CLI mode and act as the joiner whose EUI64 is 18b4300000000002.

#### wpantund
Latest wpantund is built and installed into `$(top_src)/_stage` to act as the gateway of thread network. Since d-bus policy file must be present in /etc/dbus-1/system.d, it will be deployed during the test and deleted after the test.

This tests the overall inter-operation of OpenThread, wpantund and Border Router. And it should be improved continuously.