### PR TITLE
Scripts to rule them all

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,41 @@ OTBR also provides the following services:
 
 Third-party components for Border Router Services include Simple Web Server and Material Design Lite for the framework of the web UI.
 
+# Get started
+
+We follow philosophy of [Scripts to Rule Them All](https://github.com/github/scripts-to-rule-them-all). Validated platforms include:
+
+* Raspberry Pi 3B (running recent [Raspbian Jessie Lite](https://www.raspberrypi.org/downloads/raspbian/))
+
+## Build and Install
+
+```sh
+# Install dependencies
+./script/bootstrap
+
+# Build and install border router and wpantund
+./script/setup
+```
+
+## Configure
+
+Edit `/etc/wpantund.conf` according to the comments. Basically only path to NCP's serial port is required. Plug in the NCP mode OpenThread
+device and check the corresponding device file of it. Here's an example when the device's serial port is `/dev/ttyUSB0`.
+
+```
+Config:NCP:SocketPath "/dev/ttyUSB0"
+```
+
+## Start services
+
+All border router services will be automatically started on next boot. Or you can start immediately by:
+
+```sh
+./script/server
+```
+
+Now you can access border router's Web UI through browsers and explore its features.
+
 # Need help?
 
 ## Interact

--- a/script/_initrc
+++ b/script/_initrc
@@ -1,0 +1,39 @@
+#!/bin/sh
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+set -e
+cd "$(dirname "$0")/.."
+
+STAGE_DIR=$(pwd)/._stage
+BUILD_DIR=$(pwd)/._build
+
+[ -d $STAGE_DIR ] || mkdir -v -p $STAGE_DIR
+[ -d $BUILD_DIR ] || mkdir -v -p $BUILD_DIR
+
+export PATH=$STAGE_DIR/usr/bin:$STAGE_DIR/usr/sbin:$PATH

--- a/script/_ipforward
+++ b/script/_ipforward
@@ -1,0 +1,52 @@
+#!/bin/sh
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+#   Description:
+#       This script manipulates ip forward configuration.
+#
+
+SYSCTL_IP_FORWARD=/etc/sysctl.d/60-otbr-ip-forward.conf
+
+ipforward_install()
+{
+    sudo tee $SYSCTL_IP_FORWARD <<EOF
+net.ipv6.conf.all.forwarding = 1
+net.ipv4.ip_forward = 1
+EOF
+}
+
+ipforward_uninstall()
+{
+    test ! -f $SYSCTL_IP_FORWARD || sudo rm $SYSCTL_IP_FORWARD
+}
+
+ipforward_enable()
+{
+    echo 1 | sudo tee /proc/sys/net/ipv6/conf/all/forwarding
+    echo 1 | sudo tee /proc/sys/net/ipv4/ip_forward
+}

--- a/script/_otbr
+++ b/script/_otbr
@@ -1,0 +1,70 @@
+#!/bin/sh
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+otbr_uninstall()
+{
+    if which systemctl; then
+        sudo systemctl stop otbr-web otbr-agent wpantund || true
+        sudo systemctl disable otbr-web otbr-agent wpantund || true
+        ! sudo systemctl is-enabled otbr-web
+        ! sudo systemctl is-enabled otbr-agent
+        ! sudo systemctl is-enabled wpantund
+    fi
+    sudo killall otbr-web otbr-agent || true
+
+    test ! -f config.status || sudo make uninstall
+    if which systemctl; then
+        sudo systemctl daemon-reload
+    fi
+}
+
+otbr_install()
+{
+    test -f config.status || ./configure --prefix=/usr --sysconfdir=/etc
+    make -j$(getconf _NPROCESSORS_ONLN)
+    sudo make install
+    if which systemctl; then
+        sudo systemctl daemon-reload
+        sudo systemctl enable wpantund otbr-web otbr-agent || true
+        sudo systemctl is-enabled wpantund
+        sudo systemctl is-enabled otbr-agent
+        sudo systemctl is-enabled otbr-web
+    else
+        >&2 echo 'WARNING: systemctl not found. otbr cannot start on boot.'
+    fi
+}
+
+otbr_update()
+{
+    test ! -f config.status || make distclean
+    test ! -f configure || find * -name Makefile.in -o -name configure | grep -v nlbuild-autotools | xargs rm -v
+    script/bootstrap
+
+    otbr_install
+}

--- a/script/_wpantund
+++ b/script/_wpantund
@@ -1,0 +1,62 @@
+#!/bin/sh
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+wpantund_uninstall()
+{
+    sudo killall wpantund || true
+
+    test -d $BUILD_DIR/wpantund || return 0
+
+    (cd $BUILD_DIR/wpantund &&
+        (test ! -f config.status || sudo make uninstall))
+}
+
+wpantund_install()
+{
+    test -d $BUILD_DIR/wpantund || (cd $BUILD_DIR &&
+        git clone --depth 1 https://github.com/openthread/wpantund.git)
+
+    (cd $BUILD_DIR/wpantund &&
+        (test -f configure || ./bootstrap.sh) &&
+        (test -f config.status || ./configure --prefix=/usr --sysconfdir=/etc \
+        --disable-ncp-dummy --enable-static-link-ncp-plugin=spinel) &&
+        make && sudo make install &&
+        sudo sed -i '/Config:NCP:SocketPath "\/dev/i Config:NCP:SocketPath "/dev/ttyUSB0"' /etc/wpantund.conf)
+}
+
+wpantund_update()
+{
+    test ! -d $BUILD_DIR/wpantund || (cd $BUILD_DIR/wpantund &&
+        REMOTE_COMMIT=$(git ls-remote https://github.com/openthread/wpantund.git refs/heads/master | cut -f1) &&
+        LOCAL_COMMIT=$(git rev-parse HEAD) &&
+        cd .. &&
+        (test "$REMOTE_COMMIT" = "$LOCAL_COMMIT" || rm -frv wpantund))
+
+    wpantund_install
+}

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,146 @@
+#!/bin/sh
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+#   Description:
+#       This script resolves all dependencies.
+#
+
+. "$(dirname "$0")"/_initrc
+
+install_packages_apt()
+{
+    sudo apt-get update
+    sudo apt-get install -y build-essential cmake libtool git
+
+    # For wpantund
+    sudo apt-get install -y libdbus-1-dev
+
+    # This is for configuring wpantund
+    sudo apt-get install -y autoconf-archive
+
+    # mDNS
+    sudo apt-get install -y libavahi-core-dev
+
+    # Doxygen
+    sudo apt-get install -y doxygen
+
+    # For libcoap to generate .sym and .map
+    sudo apt-get install -y ctags
+
+    # Boost
+    sudo apt-get install -y libboost-dev libboost-filesystem-dev libboost-system-dev
+
+    # npm bower
+    if ! which bower; then
+        sudo apt-get install -y curl
+        curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
+        sudo apt-get install -y nodejs
+        sudo npm -g install bower
+    fi
+}
+
+install_packages_opkg()
+{
+    echo 'opkg not supported currently' && false
+}
+
+install_packages_rpm()
+{
+    echo 'rpm not supported currently' && false
+}
+
+install_packages_brew()
+{
+    echo 'macOS not supported currently' && false
+}
+
+install_packages_source()
+{
+    echo 'source not supported currently' && false
+}
+
+install_packages()
+{
+    PM=source
+    if which apt-get; then
+        PM=apt
+    elif which rpm; then
+        PM=rpm
+    elif which opkg; then
+        PM=opkg
+    elif which brew; then
+        PM=brew
+    fi
+    install_packages_$PM
+}
+
+install_uncrustify()
+{
+    if test "$(uncrustify --version)" = 'uncrustify 0.64'; then
+        return
+    fi
+
+    BUILD_DIR=/tmp/build-$(date +%s)
+    mkdir -p $BUILD_DIR
+    (cd $BUILD_DIR &&
+        wget https://github.com/uncrustify/uncrustify/archive/uncrustify-0.64.tar.gz &&
+        tar xzf uncrustify-0.64.tar.gz &&
+        cd uncrustify-uncrustify-0.64 &&
+        mkdir build &&
+        cd build &&
+        cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr .. &&
+        make && make install DESTDIR=$STAGE_DIR &&
+        uncrustify --version)
+}
+
+install_cpputest()
+{
+    if test -f $STAGE_DIR/usr/lib/libCppUTest.a; then
+        return
+    fi
+
+    BUILD_DIR=/tmp/build-$(date +%s)
+    mkdir -p $BUILD_DIR
+    (cd $BUILD_DIR &&
+        wget https://github.com/cpputest/cpputest/archive/v3.8.tar.gz &&
+        tar xzf v3.8.tar.gz &&
+        cd cpputest-3.8 &&
+        ./autogen.sh &&
+        ./configure --prefix=/usr &&
+        make install DESTDIR=$STAGE_DIR)
+}
+
+main()
+{
+    install_packages
+    install_uncrustify
+    install_cpputest
+    ./bootstrap
+}
+
+main

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+#   Description:
+#       This script runs CI tests on travis.
+#
+
+. "$(dirname "$0")"/_initrc
+
+# IPv6 is disabled by default on travis-ci
+echo 0 | sudo tee /proc/sys/net/ipv6/conf/all/disable_ipv6
+
+script/test

--- a/script/console
+++ b/script/console
@@ -1,0 +1,58 @@
+#!/bin/sh
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+#   Description:
+#       This script starts all border router services in console mode.
+#
+
+. "$(dirname "$0")"/_initrc
+. script/_ipforward
+
+test -n "$TUN" || TUN=wpan0
+test -n "$NCP" || NCP=/dev/ttyUSB0
+
+if which systemctl; then
+    sudo systemctl stop otbr-web otbr-agent wpantund || true
+fi
+
+killall_services()
+{
+    sudo killall otbr-agent otbr-web wpantund || true
+}
+
+trap killall_services INT TERM EXIT
+
+killall_services
+ipforward_enable
+sudo sh -s <<EOF
+wpantund -I $TUN -s "$NCP" &
+sleep 3
+otbr-agent -I $TUN &
+otbr-web &
+wait
+EOF

--- a/script/server
+++ b/script/server
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+#   Description:
+#       This script starts all border router services.
+#
+
+. "$(dirname "$0")"/_initrc
+
+if which systemctl; then
+    sudo sysctl --system
+    sudo systemctl start wpantund || true
+    sudo systemctl start otbr-web otbr-agent || true
+else
+    >&2 echo 'WARNING: systemctl not found. try script/console to start in console mode.'
+    exit 1
+fi

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,48 @@
+#!/bin/sh
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+#   Description:
+#       This script builds and installs border router and dependencies.
+#
+
+. "$(dirname "$0")"/_initrc
+. script/_wpantund
+. script/_otbr
+. script/_ipforward
+
+main()
+{
+    otbr_uninstall
+    wpantund_uninstall
+    ipforward_uninstall
+    ipforward_install
+    wpantund_install
+    otbr_install
+}
+
+main

--- a/script/test
+++ b/script/test
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+#   Description:
+#       This script runs border router tests.
+#
+
+. "$(dirname "$0")"/_initrc
+
+make distcheck

--- a/script/update
+++ b/script/update
@@ -1,0 +1,49 @@
+#!/bin/sh
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+#   Description:
+#       This script re-initializes the project, then builds and installs border
+#       router services and dependencies.
+#
+
+. "$(dirname "$0")"/_initrc
+. script/_otbr
+. script/_wpantund
+. script/_ipforward
+
+main()
+{
+    otbr_uninstall
+    wpantund_uninstall
+    ipforward_uninstall
+    ipforward_install
+    wpantund_update
+    otbr_update
+}
+
+main


### PR DESCRIPTION
This PR adds several scripts according to [Scripts to rule them all](https://github.com/github/scripts-to-rule-them-all)

- *bootstrap* install dependencies.
- *setup* build and install border router, wpantund.
- *update* rebuild border router and update wpantund.
- *server* start wpantund and border router.
- *console* start border router and wpantund.
- *cibuild* used only on travis.
- *test* run test locally.