### PR TITLE
Task hooks

### DIFF
--- a/examples/platforms/raspbian/after_bootstrap
+++ b/examples/platforms/raspbian/after_bootstrap
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+#   Description:
+#       This script is called after bootstrap finishes its task.
+#
+
+sudo apt-get remove -y avahi-daemon

--- a/script/_initrc
+++ b/script/_initrc
@@ -37,3 +37,15 @@ BUILD_DIR=$(pwd)/._build
 [ -d $BUILD_DIR ] || mkdir -v -p $BUILD_DIR
 
 export PATH=$STAGE_DIR/usr/bin:$STAGE_DIR/usr/sbin:$PATH
+
+PLATFORM=$(lsb_release -i | cut -c17- | tr '[:upper:]' '[:lower:]')
+TASKNAME=$(basename $0)
+echo "Current platform is $PLATFORM"
+BEFORE_HOOK=examples/platforms/$PLATFORM/before_$TASKNAME
+AFTER_HOOK=examples/platforms/$PLATFORM/after_$TASKNAME
+if test ! -f $BEFORE_HOOK; then
+    BEFORE_HOOK=/dev/null
+fi
+if test ! -f $AFTER_HOOK; then
+    AFTER_HOOK=/dev/null
+fi

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -137,10 +137,12 @@ install_cpputest()
 
 main()
 {
+    . $BEFORE_HOOK
     install_packages
     install_uncrustify
     install_cpputest
     ./bootstrap
+    . $AFTER_HOOK
 }
 
 main

--- a/script/cibuild
+++ b/script/cibuild
@@ -32,7 +32,13 @@
 
 . "$(dirname "$0")"/_initrc
 
-# IPv6 is disabled by default on travis-ci
-echo 0 | sudo tee /proc/sys/net/ipv6/conf/all/disable_ipv6
+main()
+{
+    . $BEFORE_HOOK
+    # IPv6 is disabled by default on travis-ci
+    echo 0 | sudo tee /proc/sys/net/ipv6/conf/all/disable_ipv6
+    script/test
+    . $AFTER_HOOK
+}
 
-script/test
+main

--- a/script/console
+++ b/script/console
@@ -36,23 +36,34 @@
 test -n "$TUN" || TUN=wpan0
 test -n "$NCP" || NCP=/dev/ttyUSB0
 
-if which systemctl; then
-    sudo systemctl stop otbr-web otbr-agent wpantund || true
-fi
-
 killall_services()
 {
     sudo killall otbr-agent otbr-web wpantund || true
 }
 
-trap killall_services INT TERM EXIT
+on_exit()
+{
+    killall_services
+    . $AFTER_HOOK
+}
 
-killall_services
-ipforward_enable
-sudo sh -s <<EOF
+main()
+{
+    . $BEFORE_HOOK
+    if which systemctl; then
+        sudo systemctl stop otbr-web otbr-agent wpantund || true
+    fi
+    killall_services
+
+    trap on_exit INT TERM EXIT
+    ipforward_enable
+    sudo sh -s <<EOF
 wpantund -I $TUN -s "$NCP" &
 sleep 3
 otbr-agent -I $TUN &
 otbr-web &
 wait
 EOF
+}
+
+main

--- a/script/server
+++ b/script/server
@@ -32,11 +32,18 @@
 
 . "$(dirname "$0")"/_initrc
 
-if which systemctl; then
-    sudo sysctl --system
-    sudo systemctl start wpantund || true
-    sudo systemctl start otbr-web otbr-agent || true
-else
-    >&2 echo 'WARNING: systemctl not found. try script/console to start in console mode.'
-    exit 1
-fi
+main()
+{
+    . $BEFORE_HOOK
+    if which systemctl; then
+        sudo sysctl --system
+        sudo systemctl start wpantund || true
+        sudo systemctl start otbr-web otbr-agent || true
+    else
+        >&2 echo 'WARNING: systemctl not found. try script/console to start in console mode.'
+        exit 1
+    fi
+    . $AFTER_HOOK
+}
+
+main

--- a/script/setup
+++ b/script/setup
@@ -37,12 +37,14 @@
 
 main()
 {
+    . $BEFORE_HOOK
     otbr_uninstall
     wpantund_uninstall
     ipforward_uninstall
     ipforward_install
     wpantund_install
     otbr_install
+    . $AFTER_HOOK
 }
 
 main

--- a/script/test
+++ b/script/test
@@ -32,4 +32,11 @@
 
 . "$(dirname "$0")"/_initrc
 
-make distcheck
+main()
+{
+    . $BEFORE_HOOK
+    make distcheck
+    . $AFTER_HOOK
+}
+
+main

--- a/script/update
+++ b/script/update
@@ -38,12 +38,14 @@
 
 main()
 {
+    . $BEFORE_HOOK
     otbr_uninstall
     wpantund_uninstall
     ipforward_uninstall
     ipforward_install
     wpantund_update
     otbr_update
+    . $AFTER_HOOK
 }
 
 main


### PR DESCRIPTION
This PR involves an mechanism to allow adding hooks on certain platform before or after certain script runs its tasks.

Platform is identified based on output of `lsb_release -i`. On raspberry PI 3B, it gives `raspbian`. On ubuntu, it gives `ubuntu`.

To add a hook, create a script file in `examples/platforms/XXX` where XXX is the platform name describe above, and name the script as `before_XXX` or `after_XXX`, XXX is the script filename in `script`, an example hook is provided under `examples/platforms/raspbian/after_bootstrap` to remove *avahi-daemon* which is currently conflict with border router service.