### PR TITLE
Update otbr-agent top level namespace to ot::BorderRouter

### DIFF
--- a/src/agent/Makefile.am
+++ b/src/agent/Makefile.am
@@ -75,7 +75,6 @@ libotbr_agent_la_CPPFLAGS                                                  = \
     -I$(top_srcdir)/third_party/libcoap/repo                                 \
     -I$(top_srcdir)/third_party/libcoap/repo/include                         \
     -I$(top_srcdir)/third_party/wpantund/repo/src                            \
-    -I$(top_builddir)/third_party/wpantund/repo/src                          \
     -I$(top_srcdir)/third_party/wpantund/repo/src                            \
     -I$(top_srcdir)/third_party/wpantund/repo/src/ipc-dbus                   \
     -I$(top_srcdir)/third_party/wpantund/repo/src/wpanctl                    \

--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -51,7 +51,7 @@
 
 namespace ot {
 
-namespace BorderAgent {
+namespace BorderRouter {
 
 /**
  * Locators
@@ -329,6 +329,6 @@ void BorderAgent::HandlePSKcChanged(const uint8_t *aPSKc, void *aContext)
     static_cast<BorderAgent *>(aContext)->mDtlsServer->SetPSK(aPSKc, kSizePSKc);
 }
 
-} // namespace BorderAgent
+} // namespace BorderRouter
 
 } // namespace ot

--- a/src/agent/border_agent.hpp
+++ b/src/agent/border_agent.hpp
@@ -45,7 +45,7 @@
 
 namespace ot {
 
-namespace BorderAgent {
+namespace BorderRouter {
 
 /**
  * @addtogroup border-agent
@@ -152,7 +152,7 @@ private:
  * @}
  */
 
-} // namespace BorderAgent
+} // namespace BorderRouter
 
 } // namespace ot
 

--- a/src/agent/coap.hpp
+++ b/src/agent/coap.hpp
@@ -39,7 +39,7 @@
 
 namespace ot {
 
-namespace BorderAgent {
+namespace BorderRouter {
 
 namespace Coap {
 
@@ -279,7 +279,7 @@ public:
 
 } // namespace Coap
 
-} // namespace BorderAgent
+} // namespace BorderRouter
 
 } // namespace ot
 

--- a/src/agent/coap_libcoap.cpp
+++ b/src/agent/coap_libcoap.cpp
@@ -42,7 +42,7 @@
 
 namespace ot {
 
-namespace BorderAgent {
+namespace BorderRouter {
 
 namespace Coap {
 
@@ -305,6 +305,6 @@ void Agent::Destroy(Agent *aAgent)
 
 } // namespace Coap
 
-} // namespace BorderAgent
+} // namespace BorderRouter
 
 } // namespace ot

--- a/src/agent/coap_libcoap.hpp
+++ b/src/agent/coap_libcoap.hpp
@@ -34,7 +34,7 @@
 
 namespace ot {
 
-namespace BorderAgent {
+namespace BorderRouter {
 
 namespace Coap {
 
@@ -205,7 +205,7 @@ private:
 
 } // namespace Coap
 
-} // namespace BorderAgent
+} // namespace BorderRouter
 
 } // namespace ot
 

--- a/src/agent/dtls.hpp
+++ b/src/agent/dtls.hpp
@@ -38,7 +38,7 @@
 
 namespace ot {
 
-namespace BorderAgent {
+namespace BorderRouter {
 
 namespace Dtls {
 
@@ -214,7 +214,7 @@ public:
 
 } // namespace Dtls
 
-} // namespace BorderAgent
+} // namespace BorderRouter
 
 } // namespace ot
 

--- a/src/agent/dtls_mbedtls.cpp
+++ b/src/agent/dtls_mbedtls.cpp
@@ -42,7 +42,7 @@
 
 namespace ot {
 
-namespace BorderAgent {
+namespace BorderRouter {
 
 namespace Dtls {
 
@@ -503,6 +503,6 @@ exit:
 
 } // namespace Dtls
 
-} // namespace BorderAgent
+} // namespace BorderRouter
 
 } // namespace ot

--- a/src/agent/dtls_mbedtls.hpp
+++ b/src/agent/dtls_mbedtls.hpp
@@ -79,7 +79,7 @@ extern "C" {
 
 namespace ot {
 
-namespace BorderAgent {
+namespace BorderRouter {
 
 namespace Dtls {
 
@@ -263,7 +263,7 @@ private:
 
 } // namespace Dtls
 
-} // namespace BorderAgent
+} // namespace BorderRouter
 
 } // namespace ot
 

--- a/src/agent/main.cpp
+++ b/src/agent/main.cpp
@@ -36,7 +36,7 @@
 #include "border_agent.hpp"
 #include "common/code_utils.hpp"
 
-static const char kSyslogIdent[] = "otBorderAgent";
+static const char kSyslogIdent[] = "otbr-agent";
 static const char kDefaultInterfaceName[] = "wpan0";
 
 // Default poll timeout.
@@ -46,7 +46,7 @@ int Mainloop(const char *aInterfaceName)
 {
     int rval = 0;
 
-    ot::BorderAgent::BorderAgent br(aInterfaceName);
+    ot::BorderRouter::BorderAgent br(aInterfaceName);
 
     while (true)
     {

--- a/src/agent/ncp.hpp
+++ b/src/agent/ncp.hpp
@@ -36,7 +36,7 @@
 
 namespace ot {
 
-namespace BorderAgent {
+namespace BorderRouter {
 
 namespace Ncp {
 
@@ -160,7 +160,7 @@ public:
 
 } // Ncp
 
-} // namespace BorderAgent
+} // namespace BorderRouter
 
 } // namespace ot
 

--- a/src/agent/ncp_wpantund.cpp
+++ b/src/agent/ncp_wpantund.cpp
@@ -47,7 +47,7 @@ extern "C" {
 
 namespace ot {
 
-namespace BorderAgent {
+namespace BorderRouter {
 
 namespace Ncp {
 
@@ -501,6 +501,6 @@ void Controller::Destroy(Controller *aController)
 
 } // Ncp
 
-} // namespace BorderAgent
+} // namespace BorderRouter
 
 } // namespace ot

--- a/src/agent/ncp_wpantund.hpp
+++ b/src/agent/ncp_wpantund.hpp
@@ -47,7 +47,7 @@
 
 namespace ot {
 
-namespace BorderAgent {
+namespace BorderRouter {
 
 namespace Ncp {
 
@@ -162,7 +162,7 @@ private:
 
 } // Ncp
 
-} // namespace BorderAgent
+} // namespace BorderRouter
 
 } // namespace ot
 

--- a/tests/meshcop/Makefile.am
+++ b/tests/meshcop/Makefile.am
@@ -28,13 +28,13 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
-noinst_PROGRAMS = commissioner
+noinst_PROGRAMS = otbr-commissioner
 
-commissioner_SOURCES                                   = \
+otbr_commissioner_SOURCES                                   = \
     commissioner.cpp                                     \
     $(NULL)
 
-commissioner_CPPFLAGS                                  = \
+otbr_commissioner_CPPFLAGS                                  = \
     -DMBEDTLS_CONFIG_FILE='<config-thread.h>'            \
     -I$(top_srcdir)/third_party/mbedtls/repo/configs     \
     -I$(top_srcdir)/third_party/mbedtls/repo/include     \
@@ -43,13 +43,13 @@ commissioner_CPPFLAGS                                  = \
     -I$(top_srcdir)/src/web                              \
     $(NULL)
 
-commissioner_LDADD                                     = \
+otbr_commissioner_LDADD                                     = \
     $(top_builddir)/src/agent/libotbr-agent.la           \
     $(top_builddir)/src/utils/libutils.la                \
     $(top_builddir)/src/web/libotbr-web.la               \
     $(NULL)
 
-commissioner_LDFLAGS                                   = \
+otbr_commissioner_LDFLAGS                                   = \
     -static                                              \
     $(NULL)
 

--- a/tests/meshcop/commissioner.cpp
+++ b/tests/meshcop/commissioner.cpp
@@ -72,10 +72,10 @@
 #define MBEDTLS_DEBUG_C
 #define DEBUG_LEVEL 1
 
-#define SYSLOG_IDENT "otCommissioner"
+#define SYSLOG_IDENT "otbr-commissioner"
 
 using namespace ot;
-using namespace ot::BorderAgent;
+using namespace ot::BorderRouter;
 
 const uint8_t kSeed[] = "Commissioner";
 const uint8_t kPSKd[] = "123456";

--- a/tests/meshcop/meshcop
+++ b/tests/meshcop/meshcop
@@ -107,7 +107,7 @@ ba_start()
 
 commissioner_start()
 {
-    ./commissioner $OT_PSKC &
+    ./otbr-commissioner $OT_PSKC &
     echo 'Waitint for commissioner'
     sleep 20
 }
@@ -141,7 +141,7 @@ test_teardown()
     sudo rm -rf $STAGE_DIR
     sudo killall wpantund
     sudo killall otbr-agent
-    sudo killall commissioner
+    sudo killall otbr-commissioner
     wait
 }
 


### PR DESCRIPTION
This PR changes the top level namespace of *otbr-agent* side from `ot::BorderAgent` to `ot::BorderRouter`.