### PR TITLE
Make checks more strict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,20 @@ matrix:
     - env: BUILD_TARGET="posix-check" VERBOSE=1
       compiler: gcc
       os: linux
+    - env: BUILD_TARGET="scan-build"
+      os: linux
+      compiler: clang
+      addons:
+        apt:
+          packages:
+          - libdbus-1-dev
+          - autoconf-archive
+          - doxygen
+          - ctags
+          - libboost-dev
+          - libboost-filesystem-dev
+          - libboost-system-dev
+          - libavahi-core-dev
+          - libavahi-client-dev
+          - expect
+          - clang

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -40,7 +40,7 @@ set -e
 case $TRAVIS_OS_NAME in
 linux)
     # Uncrustify
-    [ $BUILD_TARGET != pretty-check ] || [ "$($TOOLS_HOME/usr/bin/uncrustify --version)" = 'Uncrustify-0.65' ] || (cd /tmp &&
+    [ $BUILD_TARGET != pretty-check ] || [ "$($TOOLS_HOME/usr/bin/uncrustify --version)" = 'Uncrustify-0.65_f' ] || (cd /tmp &&
         wget https://github.com/uncrustify/uncrustify/archive/uncrustify-0.65.tar.gz &&
         tar xzf uncrustify-0.65.tar.gz &&
         cd uncrustify-uncrustify-0.65 &&

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -41,11 +41,21 @@ pretty-check)
     export PATH=$TOOLS_HOME/usr/bin:$PATH || die
     ./configure && make pretty-check || die
     ;;
+
 posix-check)
     export CPPFLAGS="$CFLAGS -I$TOOLS_HOME/usr/include"
     export LDFLAGS="$LDFLAGS -L$TOOLS_HOME/usr/lib"
     ./configure && make distcheck || die
     ;;
+
+scan-build)
+    SCAN_TMPDIR=./scan-tmp
+    scan-build ./configure --disable-docs || die
+    scan-build -o $SCAN_TMPDIR -analyze-headers -v make || die
+    grep '^<!-- BUGFILE '$TRAVIS_BUILD_DIR $SCAN_TMPDIR/*/report-*.html | tee bugfiles
+    [ `< bugfiles grep -v 'third_party' | wc -l` = '0' ] || die
+    ;;
+
 *)
     die
     ;;

--- a/bootstrap
+++ b/bootstrap
@@ -33,6 +33,7 @@
 #
 
 (cd third_party/libcoap && patch -p1 < patch/0001-remove-generated-files-and-fix-separate-response.patch)
+(cd third_party/libcoap && patch -p1 < patch/0002-fix-warnings.patch)
 (cd third_party/libcoap/repo && ./autogen.sh)
 
 # Set this to the relative location of nlbuild-autotools to this script

--- a/configure.ac
+++ b/configure.ac
@@ -200,7 +200,7 @@ AC_PATH_PROG(PERL, perl)
 #   -Wall                        CC, CXX
 #
 
-PROSPECTIVE_CFLAGS="-Wall"
+PROSPECTIVE_CFLAGS="-Wall -Wextra -Wshadow -Werror"
 PROSPECTIVE_CXXFLAGS=""
 
 AX_CHECK_COMPILER_OPTIONS([C],   ${PROSPECTIVE_CFLAGS})

--- a/configure.ac
+++ b/configure.ac
@@ -200,11 +200,30 @@ AC_PATH_PROG(PERL, perl)
 #   -Wall                        CC, CXX
 #
 
-PROSPECTIVE_CFLAGS="-Wall -Wextra -Wshadow -Werror"
-PROSPECTIVE_CXXFLAGS=""
+PROSPECTIVE_CFLAGS="-Wall -Wextra -Wshadow -Werror -std=c99 -pedantic-errors"
+PROSPECTIVE_CXXFLAGS="-Wall -Wextra -Wshadow -Werror -std=gnu++98 -Wno-c++14-compat"
+
+AC_CACHE_CHECK([whether $CC is Clang],
+    [nl_cv_clang],
+    [nl_cv_clang=no
+    if test "x${GCC}" = "xyes"; then
+        AC_EGREP_CPP([NL_CC_IS_CLANG],
+            [/* Note: Clang 2.7 lacks __clang_[a-z]+__ */
+#            if defined(__clang__) && defined(__llvm__)
+             NL_CC_IS_CLANG
+#            endif
+            ],
+            [nl_cv_clang=yes])
+    fi
+    ])
+
+if test "${nl_cv_clang}" = "yes"; then
+    PROSPECTIVE_CFLAGS="${PROSPECTIVE_CFLAGS} -Wconversion"
+    PROSPECTIVE_CXXFLAGS="${PROSPECTIVE_CXXFLAGS} -Wconversion"
+fi
 
 AX_CHECK_COMPILER_OPTIONS([C],   ${PROSPECTIVE_CFLAGS})
-AX_CHECK_COMPILER_OPTIONS([C++], ${PROSPECTIVE_CFLAGS} ${PROSPECTIVE_CXXFLAGS})
+AX_CHECK_COMPILER_OPTIONS([C++], ${PROSPECTIVE_CXXFLAGS})
 
 # Check for and initialize libtool
 

--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -151,6 +151,9 @@ void BorderAgent::ForwardCommissionerRequest(const Coap::Resource &aResource, co
 
     mCoap->Send(*message, addr.m8, kCoapUdpPort, BorderAgent::ForwardCommissionerResponse);
     mCoap->FreeMessage(message);
+
+    (void)aIp6;
+    (void)aPort;
 }
 
 void BorderAgent::HandleRelayReceive(const Coap::Message &aMessage, const uint8_t *aIp6, uint16_t aPort)
@@ -168,6 +171,9 @@ void BorderAgent::HandleRelayReceive(const Coap::Message &aMessage, const uint8_
 
     mCoaps->Send(*message, NULL, 0, NULL);
     mCoaps->FreeMessage(message);
+
+    (void)aIp6;
+    (void)aPort;
 }
 
 void BorderAgent::HandleRelayTransmit(const Coap::Message &aMessage, const uint8_t *aIp6, uint16_t aPort)
@@ -207,6 +213,10 @@ void BorderAgent::HandleRelayTransmit(const Coap::Message &aMessage, const uint8
     }
 
 exit:
+
+    (void)aIp6;
+    (void)aPort;
+
     return;
 }
 

--- a/src/agent/border_agent.hpp
+++ b/src/agent/border_agent.hpp
@@ -100,6 +100,8 @@ private:
                                    Coap::Message &aResponse,
                                    const uint8_t *aIp6, uint16_t aPort, void *aContext)
     {
+        (void)aResource;
+        (void)aResponse;
         static_cast<BorderAgent *>(aContext)->HandleRelayReceive(aMessage, aIp6, aPort);
     }
     void HandleRelayReceive(const Coap::Message &aMessage, const uint8_t *aIp6, uint16_t aPort);
@@ -108,6 +110,8 @@ private:
                                     Coap::Message &aResponse,
                                     const uint8_t *aIp6, uint16_t aPort, void *aContext)
     {
+        (void)aResource;
+        (void)aResponse;
         static_cast<BorderAgent *>(aContext)->HandleRelayTransmit(aMessage, aIp6, aPort);
     }
     void HandleRelayTransmit(const Coap::Message &aMessage, const uint8_t *aIp6, uint16_t aPort);
@@ -116,6 +120,8 @@ private:
                                            Coap::Message &aResponse,
                                            const uint8_t *aIp6, uint16_t aPort, void *aContext)
     {
+        (void)aIp6;
+        (void)aResponse;
         static_cast<BorderAgent *>(aContext)->ForwardCommissionerRequest(aResource, aMessage, aIp6, aPort);
     }
     void ForwardCommissionerRequest(const Coap::Resource &aResource, const Coap::Message &aMessage,

--- a/src/agent/coap_libcoap.cpp
+++ b/src/agent/coap_libcoap.cpp
@@ -217,6 +217,9 @@ void AgentLibcoap::HandleRequest(coap_context_t *aCoap,
                                ntohs(aAddress->addr.sin6.sin6_port), agent->mContext);
         }
     }
+
+    (void)aEndPoint;
+    (void)aToken;
 }
 
 void AgentLibcoap::Input(const void *aBuffer, uint16_t aLength, const uint8_t *aIp6, uint16_t aPort)
@@ -248,6 +251,10 @@ void AgentLibcoap::HandleResponse(coap_context_t *aCoap,
     }
 
 exit:
+
+    (void)aLocalInterface;
+    (void)aRemote;
+    (void)aId;
 
     return;
 }
@@ -286,6 +293,8 @@ ssize_t AgentLibcoap::NetworkSend(coap_context_t *aCoap,
                                   const coap_address_t *aDestination,
                                   unsigned char *aBuffer, size_t aLength)
 {
+    (void)aLocalInterface;
+
     AgentLibcoap *agent = static_cast<AgentLibcoap *>(CONTAINING_RECORD(aCoap, AgentLibcoap, mCoap));
 
     return agent->mNetworkSender(aBuffer, aLength,

--- a/src/agent/dtls_mbedtls.cpp
+++ b/src/agent/dtls_mbedtls.cpp
@@ -85,6 +85,7 @@ static void MbedtlsDebug(void *ctx, int level,
     }
 
     syslog(level, "%s:%04d: %s", file, line, str);
+    (void)ctx;
 }
 
 Server *Server::Create(uint16_t aPort, StateHandler aStateHandler, void *aContext)
@@ -290,6 +291,8 @@ int MbedtlsSession::ExportKeys(void *aContext, const unsigned char *aMasterSecre
     mbedtls_sha256_starts(&sha256, 0);
     mbedtls_sha256_update(&sha256, aKeyBlock, 2 * static_cast<uint16_t>(aMacLength + aKeyLength + aIvLength));
     mbedtls_sha256_finish(&sha256, static_cast<MbedtlsSession *>(aContext)->mKek);
+
+    (void)aMasterSecret;
     return 0;
 }
 
@@ -412,6 +415,8 @@ void MbedtlsServer::UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, int &aM
 
     aTimeout.tv_sec = timeout / 1000;
     aTimeout.tv_usec = (timeout % 1000) * 1000;
+
+    (void)aWriteFdSet;
 }
 
 void MbedtlsServer::HandleSessionState(Session &aSession, Session::State aState)
@@ -450,6 +455,8 @@ exit:
     {
         syslog(LOG_ERR, "Failed to initiate new session: -0x%x", -ret);
     }
+
+    (void)aWriteFdSet;
 }
 
 void MbedtlsServer::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet)

--- a/src/agent/ncp_wpantund.cpp
+++ b/src/agent/ncp_wpantund.cpp
@@ -131,6 +131,9 @@ DBusHandlerResult ControllerWpantund::HandleProperyChangedSignal(DBusConnection 
     }
 
 exit:
+
+    (void)aConnection;
+
     return result;
 }
 

--- a/src/web/Makefile.am
+++ b/src/web/Makefile.am
@@ -28,6 +28,10 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
+# Temporary disable -Werror for the included third party server_http
+
+override CFLAGS := $(filter-out -Wshadow,$(CFLAGS))
+override CXXFLAGS := $(filter-out -Wshadow,$(CXXFLAGS))
 
 sbin_PROGRAMS = otbr-web
 

--- a/src/web/Makefile.am
+++ b/src/web/Makefile.am
@@ -30,8 +30,7 @@ include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
 # Temporary disable -Werror for the included third party server_http
 
-override CFLAGS := $(filter-out -Wshadow,$(CFLAGS))
-override CXXFLAGS := $(filter-out -Wshadow,$(CXXFLAGS))
+override CXXFLAGS := $(filter-out -std=gnu++98 -Wshadow -Werror,$(CXXFLAGS))
 
 sbin_PROGRAMS = otbr-web
 

--- a/src/web/web-service/web_service.cpp
+++ b/src/web/web-service/web_service.cpp
@@ -262,6 +262,10 @@ static std::string OnGetNetworkRequest(boost::property_tree::ptree &aGetNetworkR
     root.put("error", ret);
     std::stringstream ss;
     write_json(ss, root, false);
+
+    (void)aIfName;
+    (void)aGetNetworkRequest;
+
     return ss.str();
 }
 
@@ -306,6 +310,9 @@ exit:
     root.put("error", ret);
     std::stringstream ss;
     write_json(ss, root, false);
+
+    (void)aGetAvailableNetworkRequest;
+
     return ss.str();
 }
 
@@ -331,6 +338,10 @@ static std::string OnBootMdnsRequest(boost::property_tree::ptree &aBootMdnsReque
             });
 
     mdnsPublisherThread.detach();
+
+    (void)aBootMdnsRequest;
+    (void)aIfName;
+
     return HttpReponse(ot::Dbus::kWpantundStatus_Ok);
 }
 

--- a/src/web/wpan-controller/dbus_get.cpp
+++ b/src/web/wpan-controller/dbus_get.cpp
@@ -164,6 +164,8 @@ static void DumpInfoFromIter(char *aOutput, DBusMessageIter *aIter, int aIndent,
         strcat(aOutput, temp);
         break;
     }
+
+    (void)aBare;
 }
 
 int DBusGet::ProcessReply(void)

--- a/src/web/wpan-controller/dbus_scan.cpp
+++ b/src/web/wpan-controller/dbus_scan.cpp
@@ -113,6 +113,9 @@ DBusHandlerResult DBusScan::DbusBeaconHandler(DBusConnection *aConnection,
         }
     }
 
+    (void)aConnection;
+    (void)aUserData;
+
     return DBUS_HANDLER_RESULT_HANDLED;
 }
 

--- a/tests/meshcop/commissioner.cpp
+++ b/tests/meshcop/commissioner.cpp
@@ -188,6 +188,11 @@ void HandleJoinerFinalize(const Coap::Resource &aResource, const Coap::Message &
     // Piggyback response
     aResponse.SetCode(Coap::Message::kCoapResponseChanged);
     aResponse.SetPayload(payload, LengthOf(payload, responseTlv));
+
+    (void)aResource;
+    (void)aRequest;
+    (void)aIp6;
+    (void)aPort;
 }
 
 void HandleRelayReceive(const Coap::Resource &aResource, const Coap::Message &aMessage,
@@ -234,6 +239,12 @@ void HandleRelayReceive(const Coap::Resource &aResource, const Coap::Message &aM
     }
 
 exit:
+
+    (void)aResource;
+    (void)aResponse;
+    (void)aIp6;
+    (void)aPort;
+
     return;
 }
 
@@ -308,6 +319,9 @@ static ssize_t SendCoap(const uint8_t *aBuffer, uint16_t aLength, const uint8_t 
         }
     }
 
+    (void)aIp6;
+    (void)aPort;
+
     return ret;
 }
 
@@ -324,6 +338,12 @@ static void my_debug(void *ctx, int level,
 int export_keys(void *aContext, const unsigned char *aMasterSecret, const unsigned char *aKeyBlock,
                 size_t aMacLength, size_t aKeyLength, size_t aIvLength)
 {
+    (void)aContext;
+    (void)aMasterSecret;
+    (void)aKeyBlock;
+    (void)aMacLength;
+    (void)aKeyLength;
+    (void)aIvLength;
     return 0;
 }
 

--- a/third_party/libcoap/Makefile.am
+++ b/third_party/libcoap/Makefile.am
@@ -28,6 +28,10 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
+# Disable Werror for third_party
+
+override CFLAGS                   := $(filter-out -Werror,$(CFLAGS))
+
 # Passing --disable-examples for distcheck.
 
 DISTCHECK_CONFIGURE_FLAGS="--disable-examples"

--- a/third_party/libcoap/Makefile.am
+++ b/third_party/libcoap/Makefile.am
@@ -30,12 +30,12 @@ include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
 # Disable Werror for third_party
 
-override CFLAGS                   := $(filter-out -Werror,$(CFLAGS))
+override CFLAGS          := $(filter-out -pedantic-errors -Werror,$(CFLAGS))
 
 # Passing --disable-examples for distcheck.
 
-DISTCHECK_CONFIGURE_FLAGS="--disable-examples"
+DISTCHECK_CONFIGURE_FLAGS = "--disable-examples"
 
-SUBDIRS=repo
+SUBDIRS                   = repo
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/third_party/libcoap/patch/0001-remove-generated-files-and-fix-separate-response.patch
+++ b/third_party/libcoap/patch/0001-remove-generated-files-and-fix-separate-response.patch
@@ -284,11 +284,11 @@ index a549395..bbb6e7f 100644
 +
 +  /* when q is not NULL, it does not match (dst, token), so we can skip it */
 +  while (q) {
-+    if (coap_address_equals(dst, &context->sendqueue->remote) &&
++    if (coap_address_equals(dst, &q->remote) &&
 +        token_match(token, token_length,
-+                    context->sendqueue->pdu->hdr->token,
-+                    context->sendqueue->pdu->hdr->token_length) &&
-+        context->sendqueue->retransmit_cnt > COAP_DEFAULT_MAX_RETRANSMIT) {
++                    q->pdu->hdr->token,
++                    q->pdu->hdr->token_length) &&
++        q->retransmit_cnt > COAP_DEFAULT_MAX_RETRANSMIT) {
 +      p->next = q->next;
 +      q->next = NULL;
 +      *sent = q;

--- a/third_party/libcoap/patch/0002-fix-warnings.patch
+++ b/third_party/libcoap/patch/0002-fix-warnings.patch
@@ -1,4 +1,4 @@
-diff --git a/repo/include/coap/bits.h b/third_party/libcoap/repo/include/coap/bits.h
+diff --git a/repo/include/coap/bits.h b/repo/include/coap/bits.h
 index 0b26916..36a0b46 100644
 --- a/repo/include/coap/bits.h
 +++ b/repo/include/coap/bits.h
@@ -29,3 +29,16 @@ index 0b26916..36a0b46 100644
      return -1;
  
    return (*(vec + (bit >> 3)) & (1 << (bit & 0x07))) != 0;
+diff --git a/repo/src/resource.c b/repo/src/resource.c
+index 2967d4f..16e1ae4 100644
+--- a/repo/src/resource.c
++++ b/repo/src/resource.c
+@@ -105,7 +105,7 @@ coap_free_subscription(coap_subscription_t *subscription) {
+  
+ static int
+ match(const str *text, const str *pattern, int match_prefix, int match_substring) {
+-  assert(text); assert(pattern);
++  assert(text); assert(pattern); assert(pattern->s);
+   
+   if (text->length < pattern->length)
+     return 0;

--- a/third_party/libcoap/patch/0002-fix-warnings.patch
+++ b/third_party/libcoap/patch/0002-fix-warnings.patch
@@ -1,0 +1,31 @@
+diff --git a/repo/include/coap/bits.h b/third_party/libcoap/repo/include/coap/bits.h
+index 0b26916..36a0b46 100644
+--- a/repo/include/coap/bits.h
++++ b/repo/include/coap/bits.h
+@@ -30,7 +30,7 @@
+  */
+ inline static int
+ bits_setb(uint8_t *vec, size_t size, uint8_t bit) {
+-  if (size <= (bit >> 3))
++  if (size <= ((unsigned)bit >> 3))
+     return -1;
+ 
+   *(vec + (bit >> 3)) |= (uint8_t)(1 << (bit & 0x07));
+@@ -50,7 +50,7 @@ bits_setb(uint8_t *vec, size_t size, uint8_t bit) {
+  */
+ inline static int
+ bits_clrb(uint8_t *vec, size_t size, uint8_t bit) {
+-  if (size <= (bit >> 3))
++  if (size <= ((unsigned)bit >> 3))
+     return -1;
+ 
+   *(vec + (bit >> 3)) &= (uint8_t)(~(1 << (bit & 0x07)));
+@@ -69,7 +69,7 @@ bits_clrb(uint8_t *vec, size_t size, uint8_t bit) {
+  */
+ inline static int
+ bits_getb(const uint8_t *vec, size_t size, uint8_t bit) {
+-  if (size <= (bit >> 3))
++  if (size <= ((unsigned)bit >> 3))
+     return -1;
+ 
+   return (*(vec + (bit >> 3)) & (1 << (bit & 0x07))) != 0;

--- a/third_party/mbedtls/Makefile.am
+++ b/third_party/mbedtls/Makefile.am
@@ -62,6 +62,7 @@ libmbedtls_la_SOURCES                   = \
 libmbedtls_la_CPPFLAGS                        = \
     -I$(srcdir)/repo/include                    \
     -I$(srcdir)/repo/configs                    \
+    -D_GNU_SOURCE                               \
     -DMBEDTLS_CONFIG_FILE='<config-thread.h>'   \
     -DMBEDTLS_DEBUG_C                           \
     $(NULL)

--- a/third_party/wpantund/Makefile.am
+++ b/third_party/wpantund/Makefile.am
@@ -36,7 +36,8 @@ noinst_LTLIBRARIES = libwpanctl.la
 
 # Disable Werror for third_party
 
-override CFLAGS                   := $(filter-out -Werror,$(CFLAGS))
+override CFLAGS                   := $(filter-out -pedantic-errors -Werror,$(CFLAGS))
+override CXXFLAGS                 := $(filter-out -Werror,$(CXXFLAGS))
 
 libwpanctl_la_SOURCES              = \
     repo/src/wpanctl/wpanctl-utils.c \

--- a/third_party/wpantund/Makefile.am
+++ b/third_party/wpantund/Makefile.am
@@ -34,6 +34,10 @@ EXTRA_DIST                         = \
 
 noinst_LTLIBRARIES = libwpanctl.la
 
+# Disable Werror for third_party
+
+override CFLAGS                   := $(filter-out -Werror,$(CFLAGS))
+
 libwpanctl_la_SOURCES              = \
     repo/src/wpanctl/wpanctl-utils.c \
     $(NULL)


### PR DESCRIPTION
This PR,
1. adds `scan-build` check
2. adds `-Werror` to `CFLAGS`
3. fixes a mistake in libcoap patch
3. fixes some warnings in libcoap