### PR TITLE
Make OTBR services robust

### DIFF
--- a/src/agent/otbr-agent.service.in
+++ b/src/agent/otbr-agent.service.in
@@ -8,7 +8,7 @@ EnvironmentFile=-@sysconfdir@/default/otbr-agent
 ExecStart=@sbindir@/otbr-agent $BA_OPTS
 Restart=on-failure
 RestartSec=5
-RestartPreventExitStatus=255
+RestartPreventExitStatus=SIGKILL
 
 [Install]
 WantedBy=multi-user.target

--- a/src/web/otbr-web.service.in
+++ b/src/web/otbr-web.service.in
@@ -7,7 +7,8 @@ ConditionPathExists=@sbindir@/otbr-web
 EnvironmentFile=-@sysconfdir@/default/otbr-web
 ExecStart=@sbindir@/otbr-web $BR_OPTS
 Restart=on-failure
-RestartPreventExitStatus=255
+RestartSec=5
+RestartPreventExitStatus=SIGKILL
 
 [Install]
 WantedBy=multi-user.target

--- a/third_party/wpantund/wpantund.service.in
+++ b/third_party/wpantund/wpantund.service.in
@@ -7,7 +7,8 @@ ConditionPathExists=@sbindir@/wpantund
 EnvironmentFile=-@sysconfdir@/default/wpantund
 ExecStart=@sbindir@/wpantund $WPANTUND_OPTS
 Restart=on-failure
-RestartPreventExitStatus=255
+RestartSec=5
+RestartPreventExitStatus=SIGKILL
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Currently, OTBR mainly runs three services provided by OpenThread(wpantund, otbr-web, otbr-agent). Although they are already managed by systemd, but the configuration files are not properly set to make sure these services be restarted if some unexpected error happened. Especially for the case that NCP is unplugged, wpantund dies and will not recover.

This PR utilizes systemd's restart on-failure feature to make sure these services be restarted once exited unexpectedly. With this PR,  when unplugging NCP, systemd will try starting wpantund every 5s. Thus when the device is plugged, wpantund and otbr-agent can recover.

More information
* [1] https://www.freedesktop.org/software/systemd/man/systemd.service.html
* [2] https://www.freedesktop.org/software/systemd/man/systemd.unit.html