### PR TITLE
Fix seed mbedDTLS

### DIFF
--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -251,6 +251,7 @@ BorderAgent::BorderAgent(const char *aInterfaceName) :
         throw std::runtime_error("Failed to get Eui64");
     }
     mDtlsServer->SetSeed(eui64, kSizeEui64);
+    mDtlsServer->Start();
 }
 
 BorderAgent::~BorderAgent(void)

--- a/src/agent/dtls.hpp
+++ b/src/agent/dtls.hpp
@@ -187,6 +187,12 @@ public:
     virtual void SetSeed(const uint8_t *aSeed, uint16_t aLength) = 0;
 
     /**
+     * This method starts the DTLS service.
+     *
+     */
+    virtual void Start(void) = 0;
+
+    /**
      * This method updates the fd_set and timeout for mainloop.
      * @p aTimeout should only be updated if the DTLS service has pending process in less than its current value.
      *

--- a/src/agent/dtls_mbedtls.cpp
+++ b/src/agent/dtls_mbedtls.cpp
@@ -98,10 +98,7 @@ void Server::Destroy(Server *aServer)
     delete static_cast<MbedtlsServer *>(aServer);
 }
 
-MbedtlsServer::MbedtlsServer(uint16_t aPort, StateHandler aStateHandler, void *aContext) :
-    mPort(aPort),
-    mStateHandler(aStateHandler),
-    mContext(aContext)
+void MbedtlsServer::Start(void)
 {
     int              ret = 0;
     static const int ciphersuites[] =

--- a/src/agent/dtls_mbedtls.hpp
+++ b/src/agent/dtls_mbedtls.hpp
@@ -203,8 +203,18 @@ public:
      * @param[in]   aContext        A pointer to application-specific context.
      *
      */
-    MbedtlsServer(uint16_t aPort, StateHandler aStateHandler, void *aContext);
+    MbedtlsServer(uint16_t aPort, StateHandler aStateHandler, void *aContext) :
+        mPort(aPort),
+        mStateHandler(aStateHandler),
+        mContext(aContext) {}
     ~MbedtlsServer(void);
+
+
+    /**
+     * This method starts the DTLS service.
+     *
+     */
+    virtual void Start(void);
 
     void UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, int &aMaxFd, timeval &aTimeout);
 


### PR DESCRIPTION
This PR fixes the issue that mbedDTLS is not proper seeded. This is caused by configuring CTR_DRBG before initializing seed.