### PR TITLE
Add otbr-agent configuration file

### DIFF
--- a/src/agent/Makefile.am
+++ b/src/agent/Makefile.am
@@ -96,8 +96,9 @@ noinst_HEADERS        = \
     $(NULL)
 
 EXTRA_DIST                = \
-    otbr-agent.service.in   \
     otbr-agent.conf         \
+    otbr-agent.default      \
+    otbr-agent.service.in   \
     $(NULL)
 
 dbusconfdir = $(DBUS_CONFDIR)
@@ -107,6 +108,18 @@ systemddir=$(sysconfdir)/systemd/system
 systemd_DATA                        = \
     otbr-agent.service                \
     $(NULL)
+
+defaultdir=$(sysconfdir)/default
+
+install-data-local: $(DESTDIR)$(defaultdir)/otbr-agent
+
+# Do not overwrite existing configuration file
+$(DESTDIR)$(defaultdir)/otbr-agent: otbr-agent.default
+	test -d $(DESTDIR)$(defaultdir) || mkdir -p $(DESTDIR)$(defaultdir)
+	$(INSTALL_DATA) $(srcdir)/otbr-agent.default $(DESTDIR)$(defaultdir)/otbr-agent
+
+uninstall-local:
+	-rm $(DESTDIR)$(defaultdir)/otbr-agent
 
 .PHONY: $(systemd_DATA)
 $(systemd_DATA): %: %.in

--- a/src/agent/otbr-agent.default
+++ b/src/agent/otbr-agent.default
@@ -1,0 +1,4 @@
+# Default settings for otbr-agent. This file is sourced by systemd
+
+# Options to pass to otbr-agent
+OTBR_AGENT_OPTS="-I wpan0"

--- a/src/agent/otbr-agent.service.in
+++ b/src/agent/otbr-agent.service.in
@@ -5,7 +5,7 @@ ConditionPathExists=@sbindir@/otbr-agent
 
 [Service]
 EnvironmentFile=-@sysconfdir@/default/otbr-agent
-ExecStart=@sbindir@/otbr-agent $BA_OPTS
+ExecStart=@sbindir@/otbr-agent $OTBR_AGENT_OPTS
 Restart=on-failure
 RestartSec=5
 RestartPreventExitStatus=SIGKILL


### PR DESCRIPTION
This PR adds the default configuration file for otbr-agent.

For the sake of user friendly, the configuration file will not be overwritten by`make install`.