### PR TITLE
Add script-check Travis target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,21 +3,6 @@ language: cpp
 sudo: required
 dist: trusty
 
-addons:
-  apt:
-    packages:
-    - libdbus-1-dev
-    - autoconf-archive
-    - doxygen
-    - ctags
-    - libboost-dev
-    - libboost-filesystem-dev
-    - libboost-system-dev
-    - libavahi-common-dev
-    - libavahi-client-dev
-    - avahi-daemon
-    - expect
-
 cache:
   directories:
   - $HOME/.cache/tools
@@ -34,20 +19,9 @@ matrix:
     - env: BUILD_TARGET="raspbian-gcc" VERBOSE=1
       compiler: gcc
       os: linux
+    - env: BUILD_TARGET="script-check"
+      compiler: gcc
+      os: linux
     - env: BUILD_TARGET="scan-build"
       os: linux
       compiler: clang
-      addons:
-        apt:
-          packages:
-          - libdbus-1-dev
-          - autoconf-archive
-          - doxygen
-          - ctags
-          - libboost-dev
-          - libboost-filesystem-dev
-          - libboost-system-dev
-          - libavahi-core-dev
-          - libavahi-client-dev
-          - expect
-          - clang

--- a/bootstrap
+++ b/bootstrap
@@ -32,8 +32,8 @@
 #      nlbuild-autotools repository for this project.
 #
 
-(cd third_party/libcoap && patch -p1 < patch/0001-remove-generated-files-and-fix-separate-response.patch)
-(cd third_party/libcoap && patch -p1 < patch/0002-fix-warnings.patch)
+(cd third_party/libcoap && patch -N -p1 < patch/0001-remove-generated-files-and-fix-separate-response.patch)
+(cd third_party/libcoap && patch -N -p1 < patch/0002-fix-warnings.patch)
 (cd third_party/libcoap/repo && ./autogen.sh)
 
 # Set this to the relative location of nlbuild-autotools to this script

--- a/script/console
+++ b/script/console
@@ -38,6 +38,7 @@ test -n "$NCP" || NCP=/dev/ttyUSB0
 
 killall_services()
 {
+    echo 'Closing services...'
     sudo killall otbr-agent otbr-web wpantund || true
 }
 

--- a/script/server
+++ b/script/server
@@ -36,12 +36,19 @@
 main()
 {
     . $BEFORE_HOOK
-    which systemctl || die 'Cannot find systemctl. Try script/console to start in console mode!'
     sudo sysctl --system
     nat64_start || die 'Failed to start NAT64!'
-    systemctl is-active wpantund || sudo systemctl start wpantund || die 'Failed to start wpantund!'
-    systemctl is-active otbr-web || sudo systemctl start otbr-web || die 'Failed to start otbr-web!'
-    systemctl is-active otbr-agent || sudo systemctl start otbr-agent || die 'Failed to start otbr-agent!'
+    if which systemctl; then
+        systemctl is-active wpantund || sudo systemctl start wpantund || die 'Failed to start wpantund!'
+        systemctl is-active otbr-web || sudo systemctl start otbr-web || die 'Failed to start otbr-web!'
+        systemctl is-active otbr-agent || sudo systemctl start otbr-agent || die 'Failed to start otbr-agent!'
+    elif which service; then
+        sudo service wpantund start  || die 'Failed to start wpantund!'
+        sudo service otbr-web start || die 'Failed to start otbr-web!'
+        sudo service otbr-agent start || die 'Failed to start otbr-agent!'
+    else
+        die 'Unable to find service manager. Try script/console to start in console mode!'
+    fi
     . $AFTER_HOOK
 }
 


### PR DESCRIPTION
This PR adds a new Travis target `script-check` to check `script/*` functionality.

To keep the default NCP device path as `/dev/ttyUSB0` for wpantund, this PR simulates the NCP device with *socat* and *OpenThread NCP POSIX simulation*.

This target is not fully finished yet, because currently we only provide systemd service files, however Travis build system is based on Ubuntu trusty, which uses upstart as the init system. This target should be improved when this compatible issue was resolved.

Currently this target checks,
* `script/bootstrap`
* `script/setup`
* `script/console`