### PR TITLE
Support listening on multiple addresses.

### DIFF
--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -36,6 +36,8 @@
 
 #include <stdint.h>
 
+#define IN6ADDR_ANY "::"
+
 namespace ot {
 
 enum


### PR DESCRIPTION
This PR fixes the issue that when there are multiple address on border router. The DTLS session may not be stable and causes the DTLS session cannot be established or hang.

This is caused by mbedTLS ignores the original destination address of packets when binding the socket session. This PR retrieves the original destination, then bind and connect the socket for mbedTLS.

With this PR, border router can both support IPv4 and IPv6 on external link.