### PR TITLE
Add event emitter and refine NCP controller

### DIFF
--- a/src/agent/Makefile.am
+++ b/src/agent/Makefile.am
@@ -60,6 +60,7 @@ libotbr_agent_la_LIBADD                                       = \
     $(top_builddir)/third_party/mbedtls/libmbedtls.la           \
     $(top_builddir)/third_party/wpantund/libwpanctl.la          \
     $(top_builddir)/src/common/libotbr-logging.la               \
+    $(top_builddir)/src/common/libotbr-event-emitter.la         \
     $(DBUS_LIBS)                                                \
     $(NULL)
 

--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -220,7 +220,7 @@ exit:
 }
 
 BorderAgent::BorderAgent(const char *aInterfaceName) :
-    mNcpController(Ncp::Controller::Create(aInterfaceName, HandlePSKcChanged, FeedCoap, this)),
+    mNcpController(Ncp::Controller::Create(aInterfaceName)),
     mCoap(Coap::Agent::Create(SendCoap, kCoapResources, this)),
     mCoaps(Coap::Agent::Create(SendCoaps, kCoapsResources, this)),
     mDtlsServer(Dtls::Server::Create(kBorderAgentUdpPort, HandleDtlsSessionState, this))
@@ -234,6 +234,9 @@ BorderAgent::BorderAgent(const char *aInterfaceName) :
         otbrLog(OTBR_LOG_ERR, "failed to enable border agent proxy");
         throw std::runtime_error("Failed to start border agent proxy");
     }
+
+    mNcpController->On(Ncp::kEventPSKc, HandlePSKcChanged, this);
+    mNcpController->On(Ncp::kEventTMFProxyStream, FeedCoap, this);
 
     const uint8_t *pskc = mNcpController->GetPSKc();
     if (pskc == NULL)
@@ -306,12 +309,18 @@ ssize_t BorderAgent::SendCoaps(const uint8_t *aBuffer, uint16_t aLength, const u
     return static_cast<BorderAgent *>(aContext)->mDtlsSession->Write(aBuffer, aLength);
 }
 
-void BorderAgent::FeedCoap(const uint8_t *aBuffer, uint16_t aLength, uint16_t aLocator, uint16_t aPort, void *aContext)
+void BorderAgent::FeedCoap(void *aContext, int aEvent, va_list aArguments)
 {
-    BorderAgent *borderAgent = static_cast<BorderAgent *>(aContext);
-    Ip6Address   addr(aLocator);
+    assert(aEvent == Ncp::kEventTMFProxyStream);
 
-    borderAgent->mCoap->Input(aBuffer, aLength, addr.m8, aPort);
+    BorderAgent   *borderAgent = static_cast<BorderAgent *>(aContext);
+    const uint8_t *buffer = va_arg(aArguments, const uint8_t *);
+    uint16_t       length = va_arg(aArguments, int);
+    uint16_t       locator = va_arg(aArguments, int);
+    uint16_t       port = va_arg(aArguments, int);
+    Ip6Address     addr(locator);
+
+    borderAgent->mCoap->Input(buffer, length, addr.m8, port);
 }
 
 void BorderAgent::FeedCoaps(const uint8_t *aBuffer, uint16_t aLength, void *aContext)
@@ -334,9 +343,12 @@ void BorderAgent::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, c
     mDtlsServer->Process(aReadFdSet, aWriteFdSet);
 }
 
-void BorderAgent::HandlePSKcChanged(const uint8_t *aPSKc, void *aContext)
+void BorderAgent::HandlePSKcChanged(void *aContext, int aEvent, va_list aArguments)
 {
-    static_cast<BorderAgent *>(aContext)->mDtlsServer->SetPSK(aPSKc, kSizePSKc);
+    assert(aEvent == Ncp::kEventPSKc);
+
+    uint8_t *pskc = va_arg(aArguments, uint8_t *);
+    static_cast<BorderAgent *>(aContext)->mDtlsServer->SetPSK(pskc, kSizePSKc);
 }
 
 } // namespace BorderRouter

--- a/src/agent/border_agent.hpp
+++ b/src/agent/border_agent.hpp
@@ -81,7 +81,7 @@ public:
     void Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet);
 
 private:
-    static void FeedCoap(const uint8_t *aBuffer, uint16_t aLength, uint16_t aLocator, uint16_t aPort, void *aContext);
+    static void FeedCoap(void *aContext, int aEvent, va_list aArguments);
     static ssize_t SendCoap(const uint8_t *aBuffer, uint16_t aLength, const uint8_t *aIp6, uint16_t aPort,
                             void *aContext);
     ssize_t SendCoap(const uint8_t *aBuffer, uint16_t aLength, const uint8_t *aIp6, uint16_t aPort);
@@ -133,7 +133,7 @@ private:
     }
     void ForwardCommissionerResponse(const Coap::Message &aMessage);
 
-    static void HandlePSKcChanged(const uint8_t *aPSKc, void *aContext);
+    static void HandlePSKcChanged(void *aContext, int aEvent, va_list aArguments);
 
     /**
      * Border agent resources for Thread network.

--- a/src/agent/ncp.hpp
+++ b/src/agent/ncp.hpp
@@ -34,6 +34,8 @@
 #ifndef NCP_HPP_
 #define NCP_HPP_
 
+#include "common/event_emitter.hpp"
+
 namespace ot {
 
 namespace BorderRouter {
@@ -50,33 +52,22 @@ namespace Ncp {
  */
 
 /**
+ * NCP Events definition according to spinel protocol.
+ *
+ */
+enum
+{
+    kEventPSKc           = 0x40 + 3,
+    kEventTMFProxyStream = 0x1500 + 18,
+};
+
+/**
  * This interface defines NCP Controller functionality.
  *
  */
-class Controller
+class Controller : public EventEmitter
 {
 public:
-    /**
-     * This function pointer is called when a CoAP message ready for border agent.
-     *
-     * @param[in]   aBuffer     A pointer to packet data.
-     * @param[in]   aLength     Number of bytes in this packet.
-     * @param[in]   aLocator    Source locator of this packet.
-     * @param[in]   aPort       Source port of this packet.
-     * @param[in]   aContext    A pointer to application-specific context.
-     *
-     */
-    typedef void (*PacketHandler)(const uint8_t *aBuffer, uint16_t aLength, uint16_t aLocator, uint16_t aPort,
-                                  void *aContext);
-    /**
-     * This function pointer is called when PSKc is changed.
-     *
-     * @param[in]   aPSKc       A pointer to PSKc.
-     * @param[in]   aContext    A pointer to application-specific context.
-     *
-     */
-    typedef void (*PSKcHandler)(const uint8_t *aPSKc, void *aContext);
-
     /**
      * This method request the NCP to start the border agent proxy service.
      *
@@ -136,16 +127,18 @@ public:
     virtual const uint8_t *GetEui64(void) = 0;
 
     /**
+     * This method request the event.
+     *
+     */
+    virtual void RequestEvent(int aEvent) = 0;
+
+    /**
      * This method creates a NCP Controller.
      *
      * @param[in]   aInterfaceName  A string of the NCP interface.
-     * @param[in]   aPSKcHandler    A pointer to the function that receives the PSKc.
-     * @param[in]   aPacketHandler  A pointer to the function that handles the packet.
-     * @param[in]   aContext    A pointer to application-specific context.
      *
      */
-    static Controller *Create(const char *aInterfaceName, PSKcHandler aPSKcHandler, PacketHandler aPacketHandler,
-                              void *aContext);
+    static Controller *Create(const char *aInterfaceName);
 
     /**
      * This method destroys a NCP Controller.

--- a/src/agent/ncp_wpantund.hpp
+++ b/src/agent/ncp_wpantund.hpp
@@ -62,13 +62,9 @@ public:
      * The contructor to initialize a Ncp Controller.
      *
      * @param[in]   aInterfaceName  A string of the NCP interface.
-     * @param[in]   aPSKcHandler    A pointer to the function that receives the PSKc.
-     * @param[in]   aPacketHandler  A pointer to the function that handles the packet.
-     * @param[in]   aContext    A pointer to application-specific context.
      *
      */
-    ControllerWpantund(const char *aInterfaceName, PSKcHandler aPSKcHandler, PacketHandler aPacketHandler,
-                       void *aContext);
+    ControllerWpantund(const char *aInterfaceName);
     ~ControllerWpantund(void);
 
     /**
@@ -129,6 +125,12 @@ public:
      */
     virtual const uint8_t *GetEui64(void);
 
+    /**
+     * This method request the event.
+     *
+     */
+    virtual void RequestEvent(int aEvent);
+
 private:
     /**
      * This map is used to track DBusWatch-es.
@@ -154,9 +156,6 @@ private:
     uint8_t         mEui64[kSizeEui64];
     char            mInterfaceName[IFNAMSIZ];
     DBusConnection *mDBus;
-    PacketHandler   mPacketHandler;
-    PSKcHandler     mPSKcHandler;
-    void           *mContext;
     WatchMap        mWatches;
 };
 

--- a/src/agent/otbr-agent.conf
+++ b/src/agent/otbr-agent.conf
@@ -2,6 +2,6 @@
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
     <policy user="root">
-        <allow own="otbr.agent"/>
+        <allow own_prefix="otbr.agent"/>
     </policy>
 </busconfig>

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -28,20 +28,26 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
-noinst_HEADERS   = \
-    code_utils.hpp \
-    time.hpp       \
-    tlv.hpp        \
-    types.hpp      \
-    logging.hpp    \
+noinst_HEADERS                                        = \
+    code_utils.hpp                                      \
+    event_emitter.hpp                                   \
+    time.hpp                                            \
+    tlv.hpp                                             \
+    types.hpp                                           \
+    logging.hpp                                         \
     $(NULL)
 
-noinst_LTLIBRARIES         = \
-    libotbr-logging.la       \
+noinst_LTLIBRARIES                                    = \
+    libotbr-logging.la                                  \
+    libotbr-event-emitter.la                            \
     $(NULL)
 
-libotbr_logging_la_SOURCES = \
-    logging.cpp              \
+libotbr_logging_la_SOURCES =                            \
+    logging.cpp                                         \
+    $(NULL)
+
+libotbr_event_emitter_la_SOURCES                      = \
+    event_emitter.cpp                                   \
     $(NULL)
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/common/event_emitter.cpp
+++ b/src/common/event_emitter.cpp
@@ -1,0 +1,98 @@
+/*
+ *    Copyright (c) 2017, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "event_emitter.hpp"
+
+#include <assert.h>
+
+namespace ot {
+
+namespace BorderRouter {
+
+void EventEmitter::On(int aEvent, Callback aCallback, void *aContext)
+{
+    assert(aCallback);
+
+    Handlers &handlers = mEvents[aEvent];
+
+    handlers.push_back(Handler(aCallback, aContext));
+}
+
+void EventEmitter::Off(int aEvent, Callback aCallback, void *aContext)
+{
+    assert(aCallback);
+
+    if (!mEvents.count(aEvent))
+    {
+        return;
+    }
+
+    Handler   handler = Handler(aCallback, aContext);
+    Handlers &handlers = mEvents[aEvent];
+
+    for (Handlers::iterator it = handlers.begin(); it != handlers.end(); ++it)
+    {
+        if (*it == handler)
+        {
+            handlers.erase(it);
+            if (handlers.empty())
+            {
+                mEvents.erase(aEvent);
+            }
+            break;
+        }
+    }
+}
+
+void EventEmitter::Emit(int aEvent, ...)
+{
+    if (!mEvents.count(aEvent))
+    {
+        return;
+    }
+
+    va_list args;
+    va_start(args, aEvent);
+    Handlers &handlers = mEvents[aEvent];
+
+    assert(!handlers.empty());
+
+    for (Handlers::iterator it = handlers.begin(); it != handlers.end(); ++it)
+    {
+        va_list tmpArgs;
+        va_copy(tmpArgs, args);
+        it->first(it->second, aEvent, tmpArgs);
+        va_end(tmpArgs);
+    }
+
+    va_end(args);
+}
+
+} // namespace BorderRouter
+
+} // namespace ot

--- a/src/common/event_emitter.hpp
+++ b/src/common/event_emitter.hpp
@@ -1,0 +1,94 @@
+/*
+ *    Copyright (c) 2017, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef EVENT_EMITTER_HPP_
+#define EVENT_EMITTER_HPP_
+
+#include <map>
+#include <list>
+
+#include <stdarg.h>
+
+namespace ot {
+
+namespace BorderRouter {
+
+class EventEmitter
+{
+    /**
+     * This function pointer will be called when the @p aEvent is emitted.
+     *
+     * @param[in]   aEvent      The emitted event id.
+     * @param[in]   aArguments  The arguments associated with this event.
+     *
+     */
+    typedef void (*Callback)(void *aContext, int aEvent, va_list aArguments);
+
+public:
+
+    /**
+     * This method register an event handler for @p aEvent.
+     *
+     * @param[in]   aEvent      The event id.
+     * @param[in]   aCallback   The function poiner to be called.
+     * @param[in]   aContext    A pointer to application-specific context.
+     *
+     */
+    void On(int aEvent, Callback aCallback, void *aContext);
+
+    /**
+     * This method deregister an event handler for @p aEvent.
+     *
+     * @param[in]   aEvent      The event id.
+     * @param[in]   aCallback   The function poiner to be called.
+     * @param[in]   aContext    A pointer to application-specific context.
+     *
+     */
+    void Off(int aEvent, Callback aCallback, void *aContext);
+
+    /**
+     * This method emits an event.
+     *
+     * @param[in]   aEvent      The event id.
+     *
+     */
+    void Emit(int aEvent, ...);
+
+private:
+
+    typedef std::pair<Callback, void *>  Handler;
+    typedef std::list<Handler>           Handlers;
+    typedef std::map<int, Handlers>      Events;
+    Events mEvents;
+};
+
+} // namespace BorderRouter
+
+} // namespace ot
+
+#endif  // EVENT_EMITTER_HPP_

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -33,17 +33,20 @@ check_PROGRAMS = unittest
 unittest_SOURCES           = \
     main.cpp                 \
     test_pskc.cpp            \
+    test_event_emitter.cpp   \
     $(NULL)
 
 unittest_CPPFLAGS                                             = \
+    -I$(top_srcdir)/src                                         \
     -I$(top_srcdir)/src/agent                                   \
     -I$(top_srcdir)/src/web                                     \
     -I$(top_srcdir)/third_party/mbedtls/repo/include            \
     $(NULL)
 
-unittest_LDADD                                 = \
-    $(top_builddir)/src/agent/libotbr-agent.la   \
-    $(top_builddir)/src/web/libotbr-web.la       \
+unittest_LDADD                                                = \
+    $(top_builddir)/src/agent/libotbr-agent.la                  \
+    $(top_builddir)/src/common/libotbr-event-emitter.la         \
+    $(top_builddir)/src/web/libotbr-web.la                      \
     $(NULL)
 
 unittest_LDFLAGS             = \

--- a/tests/unit/test_event_emitter.cpp
+++ b/tests/unit/test_event_emitter.cpp
@@ -1,0 +1,182 @@
+/*
+ *    Copyright (c) 2017, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <CppUTest/TestHarness.h>
+
+#include <stdarg.h>
+
+#include "common/event_emitter.hpp"
+
+static int   sCounter = 0;
+static int   sEvent = 0;
+static void *sContext = NULL;
+
+static void HandleSingleEvent(void *aContext, int aEvent, va_list aArguments)
+{
+    sCounter++;
+
+    CHECK_EQUAL(sContext, aContext);
+    CHECK_EQUAL(sEvent, aEvent);
+    (void)aArguments;
+}
+
+static void HandleTestDifferentContextEvent(void *aContext, int aEvent, va_list aArguments)
+{
+    void *context1 = va_arg(aArguments, void *);
+    void *context2 = va_arg(aArguments, void *);
+
+    CHECK_EQUAL(sEvent, aEvent);
+
+    int id = *static_cast<int *>(aContext);
+    if (id == 1)
+    {
+        CHECK_EQUAL(context1, aContext);
+    }
+    else if (id == 2)
+    {
+        CHECK_EQUAL(context2, aContext);
+    }
+    else
+    {
+        FAIL("Unexpected id value!");
+    }
+
+    sCounter++;
+}
+
+static void HandleTestCallSequenceEvent(void *aContext, int aEvent, va_list aArguments)
+{
+    CHECK_EQUAL(sEvent, aEvent);
+
+    int id = *static_cast<int *>(aContext);
+
+    ++sCounter;
+
+    CHECK_EQUAL(sCounter, id);
+
+    (void)aArguments;
+}
+
+TEST_GROUP(EventEmitter)
+{
+};
+
+TEST(EventEmitter, TestSingleHandler)
+{
+    ot::BorderRouter::EventEmitter ee;
+    int                            event = 1;
+    ee.On(event, HandleSingleEvent, NULL);
+
+    sContext = NULL;
+    sEvent = event;
+    sCounter = 0;
+
+    ee.Emit(event);
+
+    CHECK_EQUAL(1, sCounter);
+}
+
+TEST(EventEmitter, TestDoubleHandler)
+{
+    ot::BorderRouter::EventEmitter ee;
+    int                            event = 1;
+    ee.On(event, HandleSingleEvent, NULL);
+    ee.On(event, HandleSingleEvent, NULL);
+
+    sContext = NULL;
+    sEvent = event;
+    sCounter = 0;
+
+    ee.Emit(event);
+
+    CHECK_EQUAL(2, sCounter);
+}
+
+TEST(EventEmitter, TestDifferentContext)
+{
+    ot::BorderRouter::EventEmitter ee;
+    int                            event = 2;
+
+    int context1 = 1;
+    int context2 = 2;
+
+    ee.On(event, HandleTestDifferentContextEvent, &context1);
+    ee.On(event, HandleTestDifferentContextEvent, &context2);
+
+    sContext = NULL;
+    sEvent = event;
+    sCounter = 0;
+
+    ee.Emit(event, &context1, &context2);
+
+    CHECK_EQUAL(2, sCounter);
+}
+
+TEST(EventEmitter, TestCallSequence)
+{
+    ot::BorderRouter::EventEmitter ee;
+    int                            event = 3;
+
+    int context1 = 1;
+    int context2 = 2;
+
+    ee.On(event, HandleTestCallSequenceEvent, &context1);
+    ee.On(event, HandleTestCallSequenceEvent, &context2);
+
+    sContext = NULL;
+    sEvent = event;
+    sCounter = 0;
+
+    ee.Emit(event);
+
+    CHECK_EQUAL(2, sCounter);
+}
+
+TEST(EventEmitter, TestRemoveHandler)
+{
+    ot::BorderRouter::EventEmitter ee;
+    int                            event = 3;
+
+    ee.On(event, HandleSingleEvent, NULL);
+    ee.On(event, HandleSingleEvent, NULL);
+
+    sContext = NULL;
+    sEvent = event;
+    sCounter = 0;
+
+    ee.Emit(event);
+    CHECK_EQUAL(2, sCounter);
+
+    ee.Off(event, HandleSingleEvent, NULL);
+    ee.Emit(event);
+    CHECK_EQUAL(3, sCounter);
+
+    ee.Off(event, HandleSingleEvent, NULL);
+    ee.Emit(event);
+    CHECK_EQUAL(3, sCounter);
+}


### PR DESCRIPTION
This PR implements an event emitter and refines the NCP controller with it.

Spinel defined many properties for OpenThread. The formats of those properties vary a lot. As more and more properties are to watched for changes, defining handlers for every property bloats the source code. A generic mechanism is needed.

This PR implements a simple `EventEmitter` based on `stdarg`, which supports,
* Multiple handlers for single event,
* Dynamically add and remove event handler,
* Each handler can have different context.