### PR TITLE
Add otbrDump() in the logging library.

### DIFF
--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -142,11 +142,13 @@ void BorderAgent::ForwardCommissionerRequest(const Coap::Resource &aResource, co
 
     message->SetPath(path);
 
+    Ip6Address     addr(kAloc16Leader);
     uint16_t       length = 0;
     const uint8_t *payload = aMessage.GetPayload(length);
+
     message->SetPayload(payload, length);
 
-    Ip6Address addr(kAloc16Leader);
+    otbrDump(OTBR_LOG_DEBUG, "    Payload:", payload, length);
 
     mCoap->Send(*message, addr.m8, kCoapUdpPort, BorderAgent::ForwardCommissionerResponse);
     mCoap->FreeMessage(message);
@@ -180,6 +182,8 @@ void BorderAgent::HandleRelayTransmit(const Coap::Message &aMessage, const uint8
     uint16_t       length = 0;
     const uint8_t *payload = aMessage.GetPayload(length);
     uint16_t       rloc = kInvalidLocator;
+
+    otbrLog(OTBR_LOG_DEBUG, "Relay transmit:", payload, length);
 
     for (const Tlv *tlv = reinterpret_cast<const Tlv *>(payload); tlv < reinterpret_cast<const Tlv *>(payload + length);
          tlv = tlv->GetNext())

--- a/src/agent/dtls_mbedtls.cpp
+++ b/src/agent/dtls_mbedtls.cpp
@@ -476,6 +476,8 @@ void MbedtlsServer::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet)
 
 void MbedtlsServer::SetPSK(const uint8_t *aPSK, uint8_t aLength)
 {
+    otbrDump(OTBR_LOG_DEBUG, "DTLS PSK:", aPSK, aLength);
+
     mPSKLength = aLength;
     memcpy(mPSK, aPSK, aLength);
 }

--- a/src/common/logging.hpp
+++ b/src/common/logging.hpp
@@ -29,6 +29,8 @@
 #ifndef LOGGING_HPP_
 #define LOGGING_HPP_
 
+#include <stddef.h>
+
 /**
  * Logging level, which is identical to syslog
  *
@@ -62,6 +64,17 @@ void otbrLogInit(const char *aIdent, int aLevel);
  *
  */
 void otbrLog(int aLevel, const char *aFormat, ...);
+
+/**
+ * This function dump memory as hex string at level @p aLevel.
+ *
+ * @param[in]   aLevel  Log level of the logger.
+ * @param[in]   aPrefix String before dumping memory.
+ * @param[in]   aMemory The pointer to the memory to be dumped.
+ * @param[in]   aSize   The size of memory in bytes to be dumped.
+ *
+ */
+void otbrDump(int aLevel, const char *aPrefix, const void *aMemory, size_t aSize);
 
 /**
  * This function deinitializes the logging service.


### PR DESCRIPTION
This PR adds otbrDump to dump memory as hex string for debugging.