### PR TITLE
Fix otbrDump mistake and add logging unit test.

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -100,6 +100,9 @@ linux)
     # Enable IPv6
     [ $BUILD_TARGET != posix-check ] || (echo 0 | sudo tee /proc/sys/net/ipv6/conf/all/disable_ipv6) || die
 
+    # Allow access syslog file for unit test
+    [ $BUILD_TARGET != posix-check ] || sudo chmod a+r /var/log/syslog || die
+
     # Prepare Raspbian image
     [ $BUILD_TARGET != raspbian-gcc ] || {
         sudo apt-get install --allow-unauthenticated -y qemu qemu-user-static binfmt-support parted

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -32,8 +32,9 @@ check_PROGRAMS = unittest
 
 unittest_SOURCES           = \
     main.cpp                 \
-    test_pskc.cpp            \
     test_event_emitter.cpp   \
+    test_pskc.cpp            \
+    test_logging.cpp         \
     $(NULL)
 
 unittest_CPPFLAGS                                             = \
@@ -46,6 +47,7 @@ unittest_CPPFLAGS                                             = \
 unittest_LDADD                                                = \
     $(top_builddir)/src/agent/libotbr-agent.la                  \
     $(top_builddir)/src/common/libotbr-event-emitter.la         \
+    $(top_builddir)/src/common/libotbr-logging.la               \
     $(top_builddir)/src/web/libotbr-web.la                      \
     $(NULL)
 


### PR DESCRIPTION
This PR fixes a mistake in `otbrDump()` about the size of memory. Also this PR adds a unit test for logging functionality.