### PR TITLE
Improve error handling in otbr-agent.

### DIFF
--- a/src/agent/dtls.hpp
+++ b/src/agent/dtls.hpp
@@ -36,6 +36,8 @@
 
 #include <sys/select.h>
 
+#include "common/types.hpp"
+
 namespace ot {
 
 namespace BorderRouter {
@@ -189,8 +191,12 @@ public:
     /**
      * This method starts the DTLS service.
      *
+     * @retval OTBR_ERROR_NONE  Successfully started.
+     * @retval OTBR_ERROR_ERRNO Failed to start for system error.
+     * @retval OTBR_ERROR_DTLS  Failed to start for DTLS error.
+     *
      */
-    virtual void Start(void) = 0;
+    virtual otbrError Start(void) = 0;
 
     /**
      * This method updates the fd_set and timeout for mainloop.

--- a/src/agent/dtls_mbedtls.hpp
+++ b/src/agent/dtls_mbedtls.hpp
@@ -237,8 +237,12 @@ public:
     /**
      * This method starts the DTLS service.
      *
+     * @retval OTBR_ERROR_NONE  Successfully started.
+     * @retval OTBR_ERROR_ERRNO Failed to start for system error.
+     * @retval OTBR_ERROR_DTLS  Failed to start for DTLS error.
+     *
      */
-    virtual void Start(void);
+    virtual otbrError Start(void);
 
     void UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, int &aMaxFd, timeval &aTimeout);
 
@@ -271,7 +275,7 @@ private:
 
     void HandleSessionState(Session &aSession, Session::State aState);
     void ProcessServer(const fd_set &aReadFdSet, const fd_set &aWriteFdSet);
-    int Bind(void);
+    otbrError Bind(void);
 
     SessionSet                mSessions;
     int                       mSocket;

--- a/src/agent/main.cpp
+++ b/src/agent/main.cpp
@@ -30,11 +30,13 @@
 
 #include <errno.h>
 #include <stdio.h>
+#include <string.h>
 #include <unistd.h>
 
 #include "border_agent.hpp"
 #include "common/code_utils.hpp"
 #include "common/logging.hpp"
+#include "common/types.hpp"
 
 static const char kSyslogIdent[] = "otbr-agent";
 static const char kDefaultInterfaceName[] = "wpan0";
@@ -65,8 +67,8 @@ int Mainloop(const char *aInterfaceName)
 
         if ((rval < 0) && (errno != EINTR))
         {
-            rval = errno;
-            perror("select failed");
+            rval = OTBR_ERROR_ERRNO;
+            otbrLog(OTBR_LOG_ERR, "select() failed", strerror(errno));
             break;
         }
 

--- a/src/agent/ncp.hpp
+++ b/src/agent/ncp.hpp
@@ -58,7 +58,7 @@ namespace Ncp {
 enum
 {
     kEventPSKc           = 0x40 + 3,
-    kEventTMFProxyStream = 0x1500 + 18,
+    kEventTmfProxyStream = 0x1500 + 18,
 };
 
 /**
@@ -74,7 +74,7 @@ public:
      * @returns 0 on success, otherwise failure.
      *
      */
-    virtual int BorderAgentProxyStart(void) = 0;
+    virtual otbrError TmfProxyStart(void) = 0;
 
     /**
      * This method request the NCP to stop the border agent proxy service.
@@ -82,7 +82,7 @@ public:
      * @returns 0 on success, otherwise failure.
      *
      */
-    virtual int BorderAgentProxyStop(void) = 0;
+    virtual otbrError TmfProxyStop(void) = 0;
 
     /**
      * This method sends a packet through border agent proxy service.
@@ -90,7 +90,8 @@ public:
      * @returns 0 on success, otherwise failure.
      *
      */
-    virtual int BorderAgentProxySend(const uint8_t *aBuffer, uint16_t aLength, uint16_t aLocator, uint16_t aPort) = 0;
+    virtual otbrError TmfProxySend(const uint8_t *aBuffer, uint16_t aLength,
+                                   uint16_t aLocator, uint16_t aPort) = 0;
 
     /**
      * This method updates the fd_set to poll.
@@ -115,6 +116,8 @@ public:
      *
      * @returns The current PSKc.
      *
+     * @retval  NULL    Failed to get PSKc, error code set in errno.
+     *
      */
     virtual const uint8_t *GetPSKc(void) = 0;
 
@@ -123,14 +126,21 @@ public:
      *
      * @returns The hardware address.
      *
+     * @retval  NULL    Failed to get EUI64, error code set in errno.
+     *
      */
     virtual const uint8_t *GetEui64(void) = 0;
 
     /**
      * This method request the event.
      *
+     * @param[in]   aEvent  The event id to request.
+     *
+     * @retval  OTBR_ERROR_NONE     Successfully requested the event.
+     * @retval  OTBR_ERROR_ERRNO    Failed to request the event.
+     *
      */
-    virtual void RequestEvent(int aEvent) = 0;
+    virtual otbrError RequestEvent(int aEvent) = 0;
 
     /**
      * This method creates a NCP Controller.

--- a/src/agent/ncp_wpantund.hpp
+++ b/src/agent/ncp_wpantund.hpp
@@ -70,10 +70,11 @@ public:
     /**
      * This method request the Ncp to stop the border agent proxy service.
      *
-     * @returns 0 on success, otherwise failure.
+     * @retval OTBR_ERROR_NONE  Successfully started TMF Proxy.
+     * @retval OTBR_ERROR_ERRNO Failed to start, error info in errno.
      *
      */
-    virtual int BorderAgentProxyStart(void);
+    virtual otbrError TmfProxyStart(void);
 
     /**
      * This method request the Ncp to stop the border agent proxy service.
@@ -81,7 +82,7 @@ public:
      * @returns 0 on success, otherwise failure.
      *
      */
-    virtual int BorderAgentProxyStop(void);
+    virtual otbrError TmfProxyStop(void);
 
     /**
      * This method sends a packet through border agent proxy service.
@@ -89,7 +90,7 @@ public:
      * @returns 0 on success, otherwise failure.
      *
      */
-    virtual int BorderAgentProxySend(const uint8_t *aBuffer, uint16_t aLength, uint16_t aLocator, uint16_t aPort);
+    virtual otbrError TmfProxySend(const uint8_t *aBuffer, uint16_t aLength, uint16_t aLocator, uint16_t aPort);
 
     /**
      * This method updates the fd_set to poll.
@@ -114,6 +115,8 @@ public:
      *
      * @returns The current PSKc.
      *
+     * @retval  NULL    Failed to get PSKc, error code set in errno.
+     *
      */
     virtual const uint8_t *GetPSKc(void);
 
@@ -122,14 +125,21 @@ public:
      *
      * @returns The hardware address.
      *
+     * @retval  NULL    Failed to get EUI64, error code set in errno.
+     *
      */
     virtual const uint8_t *GetEui64(void);
 
     /**
      * This method request the event.
      *
+     * @param[in]   aEvent  The event id to request.
+     *
+     * @retval  OTBR_ERROR_NONE     Successfully requested the event.
+     * @retval  OTBR_ERROR_ERRNO    Failed to request the event.
+     *
      */
-    virtual void RequestEvent(int aEvent);
+    virtual otbrError RequestEvent(int aEvent);
 
 private:
     /**
@@ -141,14 +151,15 @@ private:
     static DBusHandlerResult HandleProperyChangedSignal(DBusConnection *aConnection, DBusMessage *aMessage,
                                                         void *aContext);
     DBusHandlerResult HandleProperyChangedSignal(DBusConnection &aConnection, DBusMessage &aMessage);
+
     DBusMessage *RequestProperty(const char *aKey);
-    int      GetProperty(const char *aKey, uint8_t *aBuffer, size_t &aSize);
+    otbrError GetProperty(const char *aKey, uint8_t *aBuffer, size_t &aSize);
+
+    otbrError TmfProxyEnable(dbus_bool_t aEnable);
 
     static dbus_bool_t AddDBusWatch(struct DBusWatch *aWatch, void *aContext);
     static void RemoveDBusWatch(struct DBusWatch *aWatch, void *aContext);
     static void ToggleDBusWatch(struct DBusWatch *aWatch, void *aContext);
-
-    int BorderAgentProxyEnable(dbus_bool_t aEnable);
 
     char            mInterfaceDBusName[DBUS_MAXIMUM_NAME_LENGTH + 1];
     char            mInterfaceDBusPath[DBUS_MAXIMUM_NAME_LENGTH + 1];

--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -36,7 +36,19 @@
 
 #include <stdint.h>
 
+#ifndef IN6ADDR_ANY
 #define IN6ADDR_ANY "::"
+#endif
+
+/**
+ * This enumeration represents error codes used throughout OpenThread Border Router.
+ */
+enum otbrError
+{
+    OTBR_ERROR_NONE  = 0,  ///< No error.
+    OTBR_ERROR_ERRNO = -1, ///< Error defined by errno.
+    OTBR_ERROR_DTLS  = -2, ///< DTLS error.
+};
 
 namespace ot {
 


### PR DESCRIPTION
This PR improves the error code handling in otbr-agent. Since otbr-agent utilizes several third-party libraries, instead of defining a set of error codes, this PR defines category of error code, and tries to map errors to appropriate errno defined by POSIX and c99 if possible.