### PR TITLE
Disable libcoap documentation and installation.

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -34,6 +34,7 @@
 
 (cd third_party/libcoap && patch -N -p1 < patch/0001-remove-generated-files-and-fix-separate-response.patch)
 (cd third_party/libcoap && patch -N -p1 < patch/0002-fix-warnings.patch)
+(cd third_party/libcoap && patch -N -p1 < patch/0003-disable-documentation.patch)
 (cd third_party/libcoap/repo && ./autogen.sh)
 
 # Set this to the relative location of nlbuild-autotools to this script

--- a/configure.ac
+++ b/configure.ac
@@ -434,7 +434,7 @@ tools/Makefile
 doc/Makefile
 ])
 
-ac_configure_args="$ac_configure_args --disable-examples"
+ac_configure_args="$ac_configure_args --disable-examples --disable-documentation"
 AC_CONFIG_SUBDIRS([third_party/libcoap/repo])
 #
 # Generate the auto-generated files for the package

--- a/third_party/libcoap/Makefile.am
+++ b/third_party/libcoap/Makefile.am
@@ -34,8 +34,11 @@ override CFLAGS          := $(filter-out -pedantic-errors -Werror,$(CFLAGS))
 
 # Passing --disable-examples for distcheck.
 
-DISTCHECK_CONFIGURE_FLAGS = "--disable-examples"
+DISTCHECK_CONFIGURE_FLAGS = "--disable-examples --disable-documentation"
 
 SUBDIRS                   = repo
+
+install:
+	@echo 'Skip installing libcoap since it is static linked.'
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/third_party/libcoap/patch/0003-disable-documentation.patch
+++ b/third_party/libcoap/patch/0003-disable-documentation.patch
@@ -1,0 +1,13 @@
+diff --git a/repo/Makefile.am b/repo/Makefile.am
+index fe467ec..d8cd66d 100644
+--- a/repo/Makefile.am
++++ b/repo/Makefile.am
+@@ -29,7 +29,7 @@ EXTRA_DIST = \
+ 
+ AM_CFLAGS = -I$(top_builddir)/include/coap -I$(top_srcdir)/include/coap $(WARNING_CFLAGS) -std=c99
+ 
+-SUBDIRS = . $(DOC_DIR) tests examples
++SUBDIRS = . doc tests examples
+ 
+ ## Define a libtool archive target "libcoap-@LIBCOAP_API_VERSION@.la", with
+ ## @LIBCOAP_API_VERSION@ substituted into the generated Makefile at configure


### PR DESCRIPTION
This PR disables building libcoap documentation and skip installing this library.