### PR TITLE
Remove 'leave' operation to avoid change existing WPAN status

### DIFF
--- a/src/web/web-service/wpan_service.cpp
+++ b/src/web/web-service/wpan_service.cpp
@@ -321,8 +321,6 @@ std::string WpanService::HandleAvailableNetworkRequest()
     int                      ret = ot::Dbus::kWpantundStatus_Ok;
 
     wpanController.SetInterfaceName(mIfName);
-    VerifyOrExit(wpanController.Leave() == ot::Dbus::kWpantundStatus_Ok,
-                 ret = ot::Dbus::kWpantundStatus_LeaveFailed);
     VerifyOrExit(wpanController.Scan() == ot::Dbus::kWpantundStatus_Ok,
                  ret = ot::Dbus::kWpantundStatus_ScanFailed);
     mNetworksCount = wpanController.GetScanNetworksInfoCount();


### PR DESCRIPTION
It is not necessary to add `leave` before `scan` available networks, which may impact on the existing wpan status if the OTRB has formed or joined a Thread network.