### PR TITLE
Integrate MDNS service into mainloop.

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -71,13 +71,18 @@ linux)
         libboost-system-dev      \
         libavahi-common-dev      \
         libavahi-client-dev      \
-        avahi-daemon             \
         libjsoncpp-dev           \
         $NULL
 
     [ $BUILD_TARGET != scan-build ] || sudo apt-get install -y clang
 
-    [ $BUILD_TARGET != posix-check ] || sudo apt-get install -y expect
+    [ $BUILD_TARGET != posix-check ] || {
+        sudo apt-get install -y  \
+            expect               \
+            avahi-daemon         \
+            avahi-utils          \
+            $NULL
+    }
 
     # Uncrustify
     [ $BUILD_TARGET != pretty-check ] || [ "$($TOOLS_HOME/usr/bin/uncrustify --version)" = 'Uncrustify-0.65_f' ] || (cd /tmp &&

--- a/configure.ac
+++ b/configure.ac
@@ -428,6 +428,7 @@ src/web/Makefile
 src/common/Makefile
 src/utils/Makefile
 tests/Makefile
+tests/mdns/Makefile
 tests/meshcop/Makefile
 tests/unit/Makefile
 tools/Makefile

--- a/src/agent/Makefile.am
+++ b/src/agent/Makefile.am
@@ -53,6 +53,7 @@ libotbr_agent_la_SOURCES                                      = \
     border_agent.cpp                                            \
     coap_libcoap.cpp                                            \
     dtls_mbedtls.cpp                                            \
+    mdns_avahi.cpp                                              \
     ncp_wpantund.cpp                                            \
     $(NULL)
 
@@ -62,6 +63,8 @@ libotbr_agent_la_LIBADD                                       = \
     $(top_builddir)/third_party/wpantund/libwpanctl.la          \
     $(top_builddir)/src/common/libotbr-logging.la               \
     $(top_builddir)/src/common/libotbr-event-emitter.la         \
+    -lavahi-common                                              \
+    -lavahi-client                                              \
     $(DBUS_LIBS)                                                \
     $(NULL)
 
@@ -93,6 +96,8 @@ noinst_HEADERS        = \
     coap_libcoap.hpp    \
     dtls.hpp            \
     dtls_mbedtls.hpp    \
+    mdns.hpp            \
+    mdns_avahi.hpp      \
     ncp.hpp             \
     ncp_wpantund.hpp    \
     libcoap.h           \

--- a/src/agent/border_agent.hpp
+++ b/src/agent/border_agent.hpp
@@ -82,7 +82,7 @@ public:
     otbrError Start(void);
 
     /**
-     * This method updates the file descriptor sets with file descriptors used by border agent.
+     * This method updates the fd_set and timeout for mainloop.
      *
      * @param[inout]  aReadFdSet   A reference to read file descriptors.
      * @param[inout]  aWriteFdSet  A reference to write file descriptors.

--- a/src/agent/mdns.hpp
+++ b/src/agent/mdns.hpp
@@ -1,0 +1,170 @@
+/*
+ *    Copyright (c) 2017, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definition for MDNS service.
+ */
+
+#ifndef MDNS_HPP_
+#define MDNS_HPP_
+
+#include "common/types.hpp"
+
+namespace ot {
+
+namespace BorderRouter {
+
+namespace Mdns {
+
+/**
+ * MDNS state values.
+ *
+ */
+enum State
+{
+    kStateIdle,  ///< Unable to publishing service.
+    kStateReady, ///< Ready for publishing service.
+};
+
+/**
+ * This function pointer is called when MDNS service state changed.
+ *
+ * @param[in]   aContext        A pointer to application-specific context.
+ * @param[in]   aState          The new state.
+ *
+ */
+typedef void (*StateHandler)(void *aContext, State aState);
+
+/**
+ * @addtogroup border-router-mdns
+ *
+ * @brief
+ *   This module includes definition for MDNS service.
+ *
+ * @{
+ */
+
+/**
+ * This interface defines the functionality of MDNS service.
+ *
+ */
+class Publisher
+{
+public:
+    /**
+     * This method starts the MDNS service.
+     *
+     * @retval OTBR_ERROR_NONE  Successfully started MDNS service;
+     * @retval OTBR_ERROR_MDNS  Failed to start MDNS service.
+     *
+     */
+    virtual otbrError Start(void) = 0;
+
+    /**
+     * This method stops the MDNS service.
+     *
+     */
+    virtual void Stop(void) = 0;
+
+    /**
+     * This method publishes or updates a service.
+     *
+     * @param[in]   aName               The name of this service.
+     * @param[in]   aType               The type of this service.
+     * @param[in]   aPort               The port number of this service.
+     * @param[in]   ...                 Pointers to null-terminated string of key and value for text record.
+     *                                  The last argument must be NULL.
+     *
+     * @retval  OTBR_ERROR_NONE     Successfully published or updated the service.
+     * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the service.
+     *
+     */
+    virtual otbrError PublishService(const char *aName, const char *aType, uint16_t aPort, ...) = 0;
+
+    /**
+     * This method performs the MDNS processing.
+     *
+     * @param[in]   aReadFdSet          A reference to fd_set ready for reading.
+     * @param[in]   aWriteFdSet         A reference to fd_set ready for writing.
+     * @param[in]   aErrorFdSet         A reference to fd_set with error occurred.
+     *
+     */
+    virtual void Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet) = 0;
+
+    /**
+     * This method updates the fd_set and timeout for mainloop.
+     *
+     * @param[inout]    aReadFdSet      A reference to fd_set for polling read.
+     * @param[inout]    aWriteFdSet     A reference to fd_set for polling read.
+     * @param[inout]    aErrorFdSet     A reference to fd_set for polling error.
+     * @param[inout]    aMaxFd          A reference to the current max fd in @p aReadFdSet and @p aWriteFdSet.
+     * @param[inout]    aTimeout        A reference to the timeout. Update this value if the MDNS service has
+     *                                  pending process in less than its current value.
+     *
+     */
+    virtual void UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, fd_set &aErrorFdSet, int &aMaxFd,
+                             timeval &aTimeout) = 0;
+
+    virtual ~Publisher(void) {}
+
+    /**
+     * This function creates a MDNS publisher.
+     *
+     * @param[in]   aProtocol           Protocol to use for publishing. AF_INET6, AF_INET or AF_UNSPEC.
+     * @param[in]   aHost               The host where these services is residing on.
+     * @param[in]   aDomain             The domain to register in.
+     * @param[in]   aHandler            The function to be called when this service state changed.
+     * @param[in]   aContext            A pointer to application-specific context.
+     *
+     * @returns A pointer to the newly created MDNS publisher.
+     *
+     */
+    static Publisher *Create(int aProtocol, const char *aHost, const char *aDomain, StateHandler aHandler,
+                             void *aContext);
+
+    /**
+     * This function destroies the MDNS publisher.
+     *
+     * @param[in]   aPublisher          A pointer to the publisher.
+     *
+     */
+    static void Destroy(Publisher *aPublisher);
+};
+
+/**
+ * @}
+ */
+
+} // namespace Mdns
+
+} // namespace BorderRouter
+
+} // namespace ot
+
+#endif  // MDNS_HPP_

--- a/src/agent/mdns_avahi.cpp
+++ b/src/agent/mdns_avahi.cpp
@@ -1,0 +1,592 @@
+/*
+ *    Copyright (c) 2017, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements MDNS service based on avahi.
+ */
+
+#include "mdns_avahi.hpp"
+
+#include <stdexcept>
+
+#include <avahi-common/alternative.h>
+#include <avahi-common/malloc.h>
+#include <avahi-common/error.h>
+#include <avahi-common/timeval.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+
+#include "common/code_utils.hpp"
+#include "common/logging.hpp"
+#include "common/time.hpp"
+
+AvahiTimeout::AvahiTimeout(const struct timeval *aTimeout,
+                           AvahiTimeoutCallback aCallback,
+                           void *aContext,
+                           void *aPoller) :
+    mCallback(aCallback),
+    mContext(aContext),
+    mPoller(aPoller)
+{
+    if (aTimeout)
+    {
+        mTimeout = ot::BorderRouter::GetNow() + ot::BorderRouter::GetTimestamp(*aTimeout);
+    }
+    else
+    {
+        mTimeout = 0;
+    }
+}
+
+namespace ot {
+
+namespace BorderRouter {
+
+namespace Mdns {
+
+Poller::Poller(void)
+{
+    mAvahiPoller.userdata = this;
+    mAvahiPoller.watch_new = WatchNew;
+    mAvahiPoller.watch_update = WatchUpdate;
+    mAvahiPoller.watch_get_events = WatchGetEvents;
+    mAvahiPoller.watch_free = WatchFree;
+
+    mAvahiPoller.timeout_new = TimeoutNew;
+    mAvahiPoller.timeout_update = TimeoutUpdate;
+    mAvahiPoller.timeout_free = TimeoutFree;
+}
+
+AvahiWatch *Poller::WatchNew(const struct AvahiPoll *aPoller, int aFd, AvahiWatchEvent aEvent,
+                             AvahiWatchCallback aCallback, void *aContext)
+{
+    return reinterpret_cast<Poller *>(aPoller->userdata)->WatchNew(aFd, aEvent, aCallback, aContext);
+}
+
+AvahiWatch *Poller::WatchNew(int aFd, AvahiWatchEvent aEvent, AvahiWatchCallback aCallback, void *aContext)
+{
+    assert(aEvent && aCallback && aFd >= 0);
+
+    mWatches.push_back(new AvahiWatch(aFd, aEvent, aCallback, aContext, this));
+
+    return mWatches.back();
+}
+
+void Poller::WatchUpdate(AvahiWatch *aWatch, AvahiWatchEvent aEvent)
+{
+    aWatch->mEvents = aEvent;
+}
+
+AvahiWatchEvent Poller::WatchGetEvents(AvahiWatch *aWatch)
+{
+    return static_cast<AvahiWatchEvent>(aWatch->mHappened);
+}
+
+void Poller::WatchFree(AvahiWatch *aWatch)
+{
+    reinterpret_cast<Poller *>(aWatch->mPoller)->WatchFree(*aWatch);
+}
+
+void Poller::WatchFree(AvahiWatch &aWatch)
+{
+    for (Watches::iterator it = mWatches.begin(); it != mWatches.end(); ++it)
+    {
+        if (*it == &aWatch)
+        {
+            mWatches.erase(it);
+            delete &aWatch;
+            break;
+        }
+    }
+}
+
+AvahiTimeout *Poller::TimeoutNew(const AvahiPoll *aPoller, const struct timeval *aTimeout,
+                                 AvahiTimeoutCallback aCallback, void *aContext)
+{
+    assert(aPoller && aCallback);
+    return static_cast<Poller *>(aPoller->userdata)->TimeoutNew(aTimeout, aCallback, aContext);
+}
+
+AvahiTimeout *Poller::TimeoutNew(const struct timeval *aTimeout, AvahiTimeoutCallback aCallback, void *aContext)
+{
+    mTimers.push_back(new AvahiTimeout(aTimeout, aCallback, aContext, this));
+    return mTimers.back();
+}
+
+void Poller::TimeoutUpdate(AvahiTimeout *aTimer, const struct timeval *aTimeout)
+{
+    if (aTimeout == NULL)
+    {
+        aTimer->mTimeout = 0;
+    }
+    else
+    {
+        aTimer->mTimeout = ot::BorderRouter::GetNow() + ot::BorderRouter::GetTimestamp(*aTimeout);
+    }
+}
+
+void Poller::TimeoutFree(AvahiTimeout *aTimer)
+{
+    static_cast<Poller *>(aTimer->mPoller)->TimeoutFree(*aTimer);
+}
+
+void Poller::TimeoutFree(AvahiTimeout &aTimer)
+{
+    for (Timers::iterator it = mTimers.begin(); it != mTimers.end(); ++it)
+    {
+        if (*it == &aTimer)
+        {
+            mTimers.erase(it);
+            delete &aTimer;
+            break;
+        }
+    }
+}
+
+void Poller::UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, fd_set &aErrorFdSet, int &aMaxFd,
+                         timeval &aTimeout)
+{
+    for (Watches::iterator it = mWatches.begin(); it != mWatches.end(); ++it)
+    {
+        int             fd = (*it)->mFd;
+        AvahiWatchEvent events = (*it)->mEvents;
+
+        if (AVAHI_WATCH_IN & events)
+        {
+            FD_SET(fd, &aReadFdSet);
+        }
+
+        if (AVAHI_WATCH_OUT & events)
+        {
+            FD_SET(fd, &aWriteFdSet);
+        }
+
+        if (AVAHI_WATCH_ERR & events)
+        {
+            FD_SET(fd, &aErrorFdSet);
+        }
+
+        if (AVAHI_WATCH_HUP & events)
+        {
+            // TODO what do with this event type?
+        }
+
+        if (aMaxFd < fd)
+        {
+            aMaxFd = fd;
+        }
+
+        (*it)->mHappened = 0;
+    }
+
+    uint64_t now = GetNow();
+
+    for (Timers::iterator it = mTimers.begin(); it != mTimers.end(); ++it)
+    {
+        uint64_t timeout = (*it)->mTimeout;
+
+        if (timeout == 0)
+        {
+            continue;
+        }
+
+        if (timeout <= now)
+        {
+            aTimeout.tv_usec = 0;
+            aTimeout.tv_sec = 0;
+            break;
+        }
+        else
+        {
+            int sec;
+            int usec;
+
+            timeout -= now;
+            sec = timeout / 1000;
+            usec = (timeout % 1000) * 1000;
+
+            if (sec < aTimeout.tv_sec)
+            {
+                aTimeout.tv_sec = sec;
+            }
+            else if (sec == aTimeout.tv_sec)
+            {
+                if (usec < aTimeout.tv_usec)
+                {
+                    aTimeout.tv_usec = usec;
+                }
+            }
+        }
+    }
+}
+
+void Poller::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet)
+{
+    uint64_t now = GetNow();
+
+    for (Watches::iterator it = mWatches.begin(); it != mWatches.end(); ++it)
+    {
+        int             fd = (*it)->mFd;
+        AvahiWatchEvent events = (*it)->mEvents;
+
+        if ((AVAHI_WATCH_IN & events) && FD_ISSET(fd, &aReadFdSet))
+        {
+            (*it)->mHappened |= AVAHI_WATCH_IN;
+        }
+
+        if ((AVAHI_WATCH_OUT & events) && FD_ISSET(fd, &aWriteFdSet))
+        {
+            (*it)->mHappened |= AVAHI_WATCH_OUT;
+        }
+
+        if ((AVAHI_WATCH_ERR & events) && FD_ISSET(fd, &aErrorFdSet))
+        {
+            (*it)->mHappened |= AVAHI_WATCH_ERR;
+        }
+
+        // TODO hup events
+        if ((*it)->mHappened)
+        {
+            (*it)->mCallback(*it, (*it)->mFd, static_cast<AvahiWatchEvent>((*it)->mHappened), (*it)->mContext);
+        }
+    }
+
+    std::vector<AvahiTimeout *> expired;
+
+    for (Timers::iterator it = mTimers.begin(); it != mTimers.end(); ++it)
+    {
+        if ((*it)->mTimeout == 0)
+        {
+            continue;
+        }
+
+        if ((*it)->mTimeout <= now)
+        {
+            expired.push_back(*it);
+        }
+    }
+
+    for (std::vector<AvahiTimeout *>::iterator it = expired.begin(); it != expired.end(); ++it)
+    {
+        AvahiTimeout *avahiTimeout = *it;
+        avahiTimeout->mCallback(avahiTimeout, avahiTimeout->mContext);
+    }
+}
+
+PublisherAvahi::PublisherAvahi(int aProtocol, const char *aHost, const char *aDomain, StateHandler aHandler,
+                               void *aContext) :
+    mClient(NULL),
+    mGroup(NULL),
+    mProtocol(aProtocol == AF_INET6 ? AVAHI_PROTO_INET6 : aProtocol == AF_INET ? AVAHI_PROTO_INET : AVAHI_PROTO_UNSPEC),
+    mHost(NULL),
+    mDomain(NULL),
+    mState(kStateIdle),
+    mStateHandler(aHandler),
+    mContext(aContext)
+{
+    if (aHost)
+    {
+        mHost = strndup(aHost, kMaxSizeOfHost);
+    }
+
+    if (aDomain)
+    {
+        mDomain = strndup(aDomain, kMaxSizeOfDomain);
+    }
+}
+
+PublisherAvahi::~PublisherAvahi(void)
+{
+    if (mHost)
+    {
+        free(mHost);
+    }
+
+    if (mDomain)
+    {
+        free(mDomain);
+    }
+}
+
+otbrError PublisherAvahi::Start(void)
+{
+    otbrError ret = OTBR_ERROR_NONE;
+    int       error = 0;
+
+    mClient = avahi_client_new(mPoller.GetAvahiPoll(), AVAHI_CLIENT_NO_FAIL,
+                               HandleClientState, this, &error);
+
+    if (error)
+    {
+        otbrLog(OTBR_LOG_ERR, "Failed to create avahi client: %s!", avahi_strerror(error));
+        ret = OTBR_ERROR_MDNS;
+    }
+
+    return ret;
+}
+
+void PublisherAvahi::Stop(void)
+{
+    mServices.clear();
+
+    if (mGroup)
+    {
+        int error = avahi_entry_group_reset(mGroup);
+
+        if (error)
+        {
+            otbrLog(OTBR_LOG_ERR, "Failed to reset entry group: %s!", avahi_strerror(error));
+        }
+    }
+
+    if (mClient)
+    {
+        avahi_client_free(mClient);
+        mClient = NULL;
+        // avahi_client_free() frees all related objects, including the group.
+        mGroup = NULL;
+        mState = kStateIdle;
+        mStateHandler(mContext, mState);
+    }
+}
+
+void PublisherAvahi::HandleClientState(AvahiClient *aClient, AvahiClientState aState, void *aContext)
+{
+    static_cast<PublisherAvahi *>(aContext)->HandleClientState(aClient, aState);
+}
+
+void PublisherAvahi::HandleGroupState(AvahiEntryGroup *aGroup, AvahiEntryGroupState aState, void *aContext)
+{
+    static_cast<PublisherAvahi *>(aContext)->HandleGroupState(aGroup, aState);
+}
+
+void PublisherAvahi::HandleGroupState(AvahiEntryGroup *aGroup, AvahiEntryGroupState aState)
+{
+    assert(mGroup == aGroup || mGroup == NULL);
+
+    otbrLog(OTBR_LOG_INFO, "Avahi group change to state %d.", aState);
+    mGroup = aGroup;
+
+    /* Called whenever the entry group state changes */
+    switch (aState)
+    {
+    case AVAHI_ENTRY_GROUP_ESTABLISHED:
+        /* The entry group has been established successfully */
+        otbrLog(OTBR_LOG_INFO, "Group established.");
+        break;
+
+    case AVAHI_ENTRY_GROUP_COLLISION:
+        otbrLog(OTBR_LOG_ERR, "Name collision!");
+        break;
+
+    case AVAHI_ENTRY_GROUP_FAILURE:
+        otbrLog(OTBR_LOG_ERR, "Group failed: %s!",
+                avahi_strerror(avahi_client_errno(avahi_entry_group_get_client(aGroup))));
+        /* Some kind of failure happened while we were registering our services */
+        break;
+
+    case AVAHI_ENTRY_GROUP_UNCOMMITED:
+    case AVAHI_ENTRY_GROUP_REGISTERING:
+        otbrLog(OTBR_LOG_ERR, "Group ready.");
+        break;
+
+    default:
+        assert(false);
+        break;
+    }
+}
+
+void PublisherAvahi::CreateGroup(AvahiClient *aClient)
+{
+    VerifyOrExit(mGroup == NULL);
+
+    VerifyOrExit((mGroup = avahi_entry_group_new(aClient, HandleGroupState, this)) != NULL);
+
+exit:
+    if (mGroup == NULL)
+    {
+        otbrLog(OTBR_LOG_ERR, "avahi_entry_group_new() failed: %s", avahi_strerror(avahi_client_errno(aClient)));
+    }
+}
+
+void PublisherAvahi::HandleClientState(AvahiClient *aClient, AvahiClientState aState)
+{
+    otbrLog(OTBR_LOG_INFO, "Avahi client state changed to %d.", aState);
+    switch (aState)
+    {
+    case AVAHI_CLIENT_S_RUNNING:
+        /* The server has startup successfully and registered its host
+         * name on the network, so it's time to create our services */
+        otbrLog(OTBR_LOG_INFO, "Avahi client ready.");
+        mState = kStateReady;
+        CreateGroup(aClient);
+        mStateHandler(mContext, mState);
+        avahi_entry_group_commit(mGroup);
+        break;
+
+    case AVAHI_CLIENT_FAILURE:
+        otbrLog(OTBR_LOG_ERR, "Client failure: %s", avahi_strerror(avahi_client_errno(aClient)));
+        mState = kStateIdle;
+        mStateHandler(mContext, mState);
+        break;
+
+    case AVAHI_CLIENT_S_COLLISION:
+        /* Let's drop our registered services. When the server is back
+         * in AVAHI_SERVER_RUNNING state we will register them
+         * again with the new host name. */
+        otbrLog(OTBR_LOG_ERR, "Client collision: %s", avahi_strerror(avahi_client_errno(aClient)));
+    case AVAHI_CLIENT_S_REGISTERING:
+        /* The server records are now being established. This
+         * might be caused by a host name change. We need to wait
+         * for our own records to register until the host name is
+         * properly esatblished. */
+        if (mGroup)
+        {
+            avahi_entry_group_reset(mGroup);
+        }
+        break;
+
+    case AVAHI_CLIENT_CONNECTING:
+        otbrLog(OTBR_LOG_DEBUG, "Connecting to avahi server...");
+        break;
+
+    default:
+        assert(false);
+        break;
+    }
+}
+
+void PublisherAvahi::UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, fd_set &aErrorFdSet, int &aMaxFd,
+                                 timeval &aTimeout)
+{
+    mPoller.UpdateFdSet(aReadFdSet, aWriteFdSet, aErrorFdSet, aMaxFd, aTimeout);
+}
+
+void PublisherAvahi::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet)
+{
+    mPoller.Process(aReadFdSet, aWriteFdSet, aErrorFdSet);
+}
+
+otbrError PublisherAvahi::PublishService(const char *aName, const char *aType, uint16_t aPort, ...)
+{
+    otbrError ret = OTBR_ERROR_ERRNO;
+    int       error = 0;
+    // aligned with AvahiStringList
+    AvahiStringList  buffer[kMaxSizeOfTxtRecord / sizeof(AvahiStringList)];
+    AvahiStringList *last = NULL;
+    AvahiStringList *curr = buffer;
+    va_list          args;
+    size_t           used = 0;
+
+    va_start(args, aPort);
+
+    VerifyOrExit(mState == kStateReady, errno = EAGAIN);
+
+    for (const char *name = va_arg(args, const char *); name; name = va_arg(args, const char *))
+    {
+        const char *value = va_arg(args, const char *);
+        size_t      needed = sizeof(AvahiStringList) + strlen(name) + strlen(value);
+        VerifyOrExit(used + needed < sizeof(buffer), errno = EMSGSIZE);
+        curr->next = last;
+        last = curr;
+        curr->size = sprintf(reinterpret_cast<char *>(curr->text), "%s=%s", name, value);
+        {
+            const uint8_t *next = curr->text + curr->size;
+            curr = OTBR_ALIGNED(next, AvahiStringList *);
+        }
+        used = reinterpret_cast<uint8_t *>(curr) - reinterpret_cast<uint8_t *>(buffer);
+    }
+
+    for (Services::iterator it = mServices.begin(); it != mServices.end(); ++it)
+    {
+        if (!strncmp(it->mName, aName, sizeof(it->mName)) &&
+            !strncmp(it->mType, aType, sizeof(it->mType)) &&
+            it->mPort == aPort)
+        {
+            otbrLog(OTBR_LOG_INFO, "MDNS updating service %s...", aName);
+            error = avahi_entry_group_update_service_txt_strlst(mGroup, AVAHI_IF_UNSPEC, mProtocol,
+                                                                static_cast<AvahiPublishFlags>(0), aName, aType,
+                                                                mDomain, last);
+            SuccessOrExit(error);
+            ret = OTBR_ERROR_NONE;
+            ExitNow();
+        }
+    }
+
+    otbrLog(OTBR_LOG_INFO, "MDNS creating service %s...", aName);
+    error = avahi_entry_group_add_service_strlst(mGroup, AVAHI_IF_UNSPEC, mProtocol,
+                                                 static_cast<AvahiPublishFlags>(0), aName, aType, mDomain,
+                                                 mHost, aPort, last);
+    SuccessOrExit(error);
+
+    {
+        Service service;
+        strncpy(service.mName, aName, sizeof(service.mName));
+        strncpy(service.mType, aType, sizeof(service.mType));
+        service.mPort = aPort;
+        mServices.push_back(service);
+    }
+
+    ret = OTBR_ERROR_NONE;
+
+exit:
+    va_end(args);
+
+    if (error)
+    {
+        ret = OTBR_ERROR_MDNS;
+        otbrLog(OTBR_LOG_ERR, "Failed to publish service for avahi error: %s!", avahi_strerror(error));
+    }
+
+    if (ret == OTBR_ERROR_ERRNO)
+    {
+        otbrLog(OTBR_LOG_ERR, "Failed to publish service: %s!", strerror(errno));
+    }
+
+    return ret;
+}
+
+Publisher *Publisher::Create(int aFamily, const char *aHost, const char *aDomain, StateHandler aHandler, void *aContext)
+{
+    return new PublisherAvahi(aFamily, aHost, aDomain, aHandler, aContext);
+}
+
+void Publisher::Destroy(Publisher *aPublisher)
+{
+    delete static_cast<PublisherAvahi *>(aPublisher);
+}
+
+} // namespace Mdns
+
+} // namespace BorderRouter
+
+} // namespace ot

--- a/src/agent/mdns_avahi.hpp
+++ b/src/agent/mdns_avahi.hpp
@@ -1,0 +1,315 @@
+/*
+ *    Copyright (c) 2017, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definition for MDNS service based on avahi.
+ */
+
+#ifndef MDNS_AVAHI_HPP_
+#define MDNS_AVAHI_HPP_
+
+#include <vector>
+
+#include <avahi-client/client.h>
+#include <avahi-client/publish.h>
+#include <avahi-common/watch.h>
+#include <avahi-common/domain.h>
+#include <sys/select.h>
+
+#include "mdns.hpp"
+
+/**
+ * @addtogroup border-router-mdns
+ *
+ * @brief
+ *   This module includes definition for avahi-based MDNS service.
+ *
+ * @{
+ */
+
+/**
+ * This structure implements AvahiWatch.
+ *
+ */
+struct AvahiWatch
+{
+    int                mFd;       ///< The file descriptor to watch.
+    AvahiWatchEvent    mEvents;   ///< The interested events.
+    int                mHappened; ///< The events happened.
+    AvahiWatchCallback mCallback; ///< The function to be called when interested events happened on mFd.
+    void              *mContext;  ///< A pointer to application-specific context.
+    void              *mPoller;   ///< The poller created this watch.
+
+    /**
+     * The constructor to initialize an Avahi watch.
+     *
+     * @param[in]   aFd         The file descriptor to watch.
+     * @param[in]   aEvents     The events to watch.
+     * @param[in]   aCallback   The function to be called when events happend on this file descriptor.
+     * @param[in]   aContext    A pointer to application-specific context.
+     * @param[in]   aPoller     The Poller this watcher belongs to.
+     *
+     */
+    AvahiWatch(int aFd,
+               AvahiWatchEvent aEvents,
+               AvahiWatchCallback aCallback,
+               void *aContext,
+               void *aPoller) :
+        mFd(aFd),
+        mEvents(aEvents),
+        mCallback(aCallback),
+        mContext(aContext),
+        mPoller(aPoller) {}
+};
+
+/**
+ * This structure implements the AvahiTimeout.
+ *
+ */
+struct AvahiTimeout
+{
+    uint64_t             mTimeout;  ///< Absolute time when this timer timeout.
+    AvahiTimeoutCallback mCallback; ///< The function to be called when timeout.
+    void                *mContext;  ///< The pointer to application-specific context.
+    void                *mPoller;   ///< The poller created this timer.
+
+    /**
+     * The constructor to initialize an AvahiTimeout.
+     *
+     * @param[in]   aTimeout    A pointer to the time after which the callback should be called.
+     * @param[in]   aCallback   The function to be called after timeout.
+     * @param[in]   aContext    A pointer to application-specific context.
+     * @param[in]   aPoller     The Poller this timeout belongs to.
+     *
+     */
+    AvahiTimeout(const struct timeval *aTimeout,
+                 AvahiTimeoutCallback aCallback,
+                 void *aContext,
+                 void *aPoller);
+};
+
+namespace ot {
+
+namespace BorderRouter {
+
+namespace Mdns {
+
+/**
+ * This class implements the AvahiPoll.
+ *
+ */
+class Poller
+{
+public:
+    /**
+     * The constructor to initialize a Poller.
+     *
+     */
+    Poller(void);
+
+    /**
+     * This method updates the fd_set and timeout for mainloop.
+     *
+     * @param[inout]    aReadFdSet      A reference to fd_set for polling read.
+     * @param[inout]    aWriteFdSet     A reference to fd_set for polling write.
+     * @param[inout]    aErrorFdSet     A reference to fd_set for polling error.
+     * @param[inout]    aMaxFd          A reference to the max file descriptor.
+     * @param[inout]    aTimeout        A reference to the timeout.
+     *
+     */
+    void UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, fd_set &aErrorFdSet, int &aMaxFd,
+                     timeval &aTimeout);
+
+    /**
+     * This method performs avahi poll processing.
+     *
+     * @param[in]   aReadFdSet   A reference to read file descriptors.
+     * @param[in]   aWriteFdSet  A reference to write file descriptors.
+     * @param[in]   aErrorFdSet  A reference to error file descriptors.
+     *
+     */
+    void Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet);
+
+    /**
+     * This method returns the AvahiPoll.
+     *
+     * @returns A pointer to the AvahiPoll.
+     *
+     */
+    const AvahiPoll *GetAvahiPoll(void) const { return &mAvahiPoller; }
+
+private:
+    typedef std::vector<AvahiWatch *> Watches;
+    typedef std::vector<AvahiTimeout *> Timers;
+
+    static AvahiWatch *WatchNew(const struct AvahiPoll *aPoller, int aFd, AvahiWatchEvent aEvent,
+                                AvahiWatchCallback aCallback, void *aContext);
+    AvahiWatch *WatchNew(int aFd, AvahiWatchEvent aEvent, AvahiWatchCallback aCallback, void *aContext);
+    static void WatchUpdate(AvahiWatch *aWatch, AvahiWatchEvent aEvent);
+    static AvahiWatchEvent WatchGetEvents(AvahiWatch *aWatch);
+    static void WatchFree(AvahiWatch *aWatch);
+    void WatchFree(AvahiWatch &aWatch);
+    static AvahiTimeout *TimeoutNew(const AvahiPoll *aPoller, const struct timeval *aTimeout,
+                                    AvahiTimeoutCallback aCallback, void *aContext);
+    AvahiTimeout *TimeoutNew(const struct timeval *aTimeout, AvahiTimeoutCallback aCallback, void *aContext);
+    static void TimeoutUpdate(AvahiTimeout *aTimer, const struct timeval *aTimeout);
+    static void TimeoutFree(AvahiTimeout *aTimer);
+    void TimeoutFree(AvahiTimeout &aTimer);
+
+
+    Watches   mWatches;
+    Timers    mTimers;
+    AvahiPoll mAvahiPoller;
+};
+
+/**
+ * This class implements MDNS service with avahi.
+ *
+ */
+class PublisherAvahi : public Publisher
+{
+public:
+    /**
+     * The constructor to initialize a Publisher.
+     *
+     * @param[in]   aProtocol           The protocol used for publishing. IPv4, IPv6 or both.
+     * @param[in]   aHost               The name of host residing the services to be published.
+                                        NULL to use default.
+     * @param[in]   aDomain             The domain of the host. NULL to use default.
+     * @param[in]   aHandler            The function to be called when state changes.
+     * @param[in]   aContext            A pointer to application-specific context.
+     *
+     */
+    PublisherAvahi(int aProtocol, const char *aHost, const char *aDomain, StateHandler aHandler, void *aContext);
+
+    ~PublisherAvahi(void);
+
+    /**
+     * This method publishes or updates a service.
+     *
+     * @note only text record can be updated.
+     *
+     * @param[in]   aName               The name of this service.
+     * @param[in]   aType               The type of this service.
+     * @param[in]   aPort               The port number of this service.
+     * @param[in]   ...                 Pointers to null-terminated string of key and value for text record.
+     *                                  The last argument must be NULL.
+     *
+     * @retval  OTBR_ERROR_NONE     Successfully published or updated the service.
+     * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the service.
+     *
+     */
+    otbrError PublishService(const char *aName, const char *aType, uint16_t aPort, ...);
+
+    /**
+     * This method starts the MDNS service.
+     *
+     * @retval OTBR_ERROR_NONE  Successfully started MDNS service;
+     * @retval OTBR_ERROR_MDNS  Failed to start MDNS service.
+     *
+     */
+    otbrError Start(void);
+
+    /**
+     * This method stops the MDNS service.
+     *
+     */
+    void Stop(void);
+
+    /**
+     * This method performs avahi poll processing.
+     *
+     * @param[in]   aReadFdSet          A reference to read file descriptors.
+     * @param[in]   aWriteFdSet         A reference to write file descriptors.
+     * @param[in]   aErrorFdSet         A reference to error file descriptors.
+     *
+     */
+    void Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet);
+
+    /**
+     * This method updates the fd_set and timeout for mainloop.
+     *
+     * @param[inout]    aReadFdSet      A reference to fd_set for polling read.
+     * @param[inout]    aWriteFdSet     A reference to fd_set for polling write.
+     * @param[inout]    aErrorFdSet     A reference to fd_set for polling error.
+     * @param[inout]    aMaxFd          A reference to the max file descriptor.
+     * @param[inout]    aTimeout        A reference to the timeout.
+     *
+     */
+    void UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, fd_set &aErrorFdSet, int &aMaxFd,
+                     timeval &aTimeout);
+
+private:
+    enum
+    {
+        kMaxSizeOfTxtRecord   = 128,
+        kMaxSizeOfServiceName = AVAHI_LABEL_MAX,
+        kMaxSizeOfHost        = AVAHI_LABEL_MAX,
+        kMaxSizeOfDomain      = AVAHI_LABEL_MAX,
+        kMaxSizeOfServiceType = AVAHI_LABEL_MAX,
+    };
+
+    struct Service
+    {
+        char     mName[kMaxSizeOfServiceName];
+        char     mType[kMaxSizeOfServiceType];
+        uint16_t mPort;
+    };
+
+    typedef std::vector<Service> Services;
+
+    static void HandleClientState(AvahiClient *aClient, AvahiClientState aState, void *aContext);
+    void HandleClientState(AvahiClient *aClient, AvahiClientState aState);
+
+    void CreateGroup(AvahiClient *aClient);
+    static void HandleGroupState(AvahiEntryGroup *aGroup, AvahiEntryGroupState aState, void *aContext);
+    void HandleGroupState(AvahiEntryGroup *aGroup, AvahiEntryGroupState aState);
+
+    Services         mServices;
+    AvahiClient     *mClient;
+    AvahiEntryGroup *mGroup;
+    Poller           mPoller;
+    int              mProtocol;
+    char            *mHost;
+    char            *mDomain;
+    State            mState;
+    StateHandler     mStateHandler;
+    void            *mContext;
+};
+
+} // namespace Mdns
+
+} // namespace BorderRouter
+
+} // namespace ot
+
+/**
+ * @}
+ */
+#endif // MDNS_AVAHI_HPP_

--- a/src/common/code_utils.hpp
+++ b/src/common/code_utils.hpp
@@ -26,8 +26,21 @@
  *    POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef UTILS_HPP_
-#define UTILS_HPP_
+#ifndef CODE_UTILS_HPP_
+#define CODE_UTILS_HPP_
+
+/**
+ *  This aligns the pointer to @p aAlignType.
+ *
+ *  @param[in]  aMem        A pointer to abitrary memory.
+ *  @param[in]  aAlignType  The type to align with and convert the pointer to this type.
+ *
+ *  @returns A @aAlignType pointer to aligned memory.
+ *
+ */
+#define OTBR_ALIGNED(aMem, aAlignType)                                      \
+    reinterpret_cast<aAlignType>((((long)(aMem) + sizeof(aAlignType) - 1) / \
+                                  sizeof(aAlignType)) * sizeof(aAlignType))
 
 #ifndef CONTAINING_RECORD
 #define BASE 0x1
@@ -92,4 +105,4 @@
         goto exit;                              \
     } while (false)
 
-#endif // UTILS_HPP_
+#endif // CODE_UTILS_HPP_

--- a/src/common/time.hpp
+++ b/src/common/time.hpp
@@ -33,6 +33,24 @@
 
 #include <sys/time.h>
 
+namespace ot {
+
+namespace BorderRouter {
+
+
+/**
+ * This method returns the timestamp in miniseconds of @aTime.
+ *
+ * @param[in]   aTime   The time to convert to timestamp.
+ *
+ * @returns timestamp in miniseconds.
+ *
+ */
+inline uint64_t GetTimestamp(const timeval &aTime)
+{
+    return aTime.tv_sec * 1000 + aTime.tv_usec / 1000;
+}
+
 /**
  * This method returns the current timestamp in miniseconds.
  *
@@ -46,4 +64,8 @@ inline uint64_t GetNow(void) {
     return now.tv_sec * 1000 + now.tv_usec / 1000;
 }
 
-#endif // TIME_HPP_
+} // namespace BorderRouter
+
+} // namespace ot
+
+#endif  // TIME_HPP_

--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -53,6 +53,7 @@ enum otbrError
     OTBR_ERROR_ERRNO = -1, ///< Error defined by errno.
     OTBR_ERROR_DTLS  = -2, ///< DTLS error.
     OTBR_ERROR_DBUS  = -3, ///< DBus error.
+    OTBR_ERROR_MDNS  = -4, ///< MDNS error.
 };
 
 namespace ot {

--- a/tests/mdns/Makefile.am
+++ b/tests/mdns/Makefile.am
@@ -28,10 +28,36 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
-SUBDIRS         = \
-    unit          \
-    mdns          \
-    meshcop       \
+noinst_PROGRAMS = otbr-test-mdns
+
+otbr_test_mdns_SOURCES                                 = \
+    main.cpp                                             \
+    $(NULL)
+
+otbr_test_mdns_CPPFLAGS                                = \
+    -I$(top_srcdir)/src                                  \
+    $(NULL)
+
+otbr_test_mdns_LDADD                                   = \
+    $(top_builddir)/src/agent/libotbr-agent.la           \
+    $(NULL)
+
+otbr_test_mdns_LDFLAGS                                 = \
+    -static                                              \
+    $(NULL)
+
+EXTRA_DIST                                             = \
+    test-single                                          \
+    test-multiple                                        \
+    test-update                                          \
+    test-stop                                            \
+    $(NULL)
+
+TESTS                                                  = \
+    test-single                                          \
+    test-multiple                                        \
+    test-update                                          \
+    test-stop                                            \
     $(NULL)
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/tests/mdns/main.cpp
+++ b/tests/mdns/main.cpp
@@ -1,0 +1,241 @@
+/*
+ *    Copyright (c) 2017, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <limits.h>
+#include <netinet/in.h>
+#include <signal.h>
+#include <stdio.h>
+#include <time.h>
+
+#include "agent/mdns.hpp"
+#include "common/code_utils.hpp"
+#include "common/logging.hpp"
+
+using namespace ot::BorderRouter;
+
+static struct Context
+{
+    Mdns::Publisher *mPublisher;
+    bool             mUpdate;
+} context;
+
+int Mainloop(Mdns::Publisher &aPublisher)
+{
+    int rval = 0;
+
+    while (true)
+    {
+        fd_set         readFdSet;
+        fd_set         writeFdSet;
+        fd_set         errorFdSet;
+        int            maxFd = -1;
+        struct timeval timeout = {
+            INT_MAX, INT_MAX
+        };
+
+        FD_ZERO(&readFdSet);
+        FD_ZERO(&writeFdSet);
+        FD_ZERO(&errorFdSet);
+
+        aPublisher.UpdateFdSet(readFdSet, writeFdSet, errorFdSet, maxFd, timeout);
+        rval = select(maxFd + 1, &readFdSet, &writeFdSet, &errorFdSet, (timeout.tv_sec == INT_MAX ? NULL : &timeout));
+
+        if (rval < 0)
+        {
+            perror("select() failed");
+            break;
+        }
+
+        aPublisher.Process(readFdSet, writeFdSet, errorFdSet);
+    }
+
+    return rval;
+}
+
+void PublishSingleService(void *aContext, Mdns::State aState)
+{
+    assert(aContext == &context);
+
+    if (aState == Mdns::kStateReady)
+    {
+        assert(OTBR_ERROR_NONE ==
+               context.mPublisher->PublishService("SingleService", "_meshcop._udp", 12345, "nn", "cool", "xp",
+                                                  "1122334455667788", NULL));
+    }
+}
+
+void PublishMultipleServices(void *aContext, Mdns::State aState)
+{
+    assert(aContext == &context);
+
+    if (aState == Mdns::kStateReady)
+    {
+        assert(OTBR_ERROR_NONE ==
+               context.mPublisher->PublishService("MultipleService1", "_meshcop._udp", 12345, "nn", "cool1", "xp",
+                                                  "1122334455667788", NULL));
+        assert(OTBR_ERROR_NONE ==
+               context.mPublisher->PublishService("MultipleService2", "_meshcop._udp", 12346, "nn", "cool2", "xp",
+                                                  "1122334455667788", NULL));
+    }
+}
+
+void PublishUpdateServices(void *aContext, Mdns::State aState)
+{
+    assert(aContext == &context);
+
+    if (aState == Mdns::kStateReady)
+    {
+        if (!context.mUpdate)
+        {
+            assert(OTBR_ERROR_NONE ==
+                   context.mPublisher->PublishService("UpdateService", "_meshcop._udp", 12345, "nn", "cool", "xp",
+                                                      "1122334455667788", NULL));
+        }
+        else
+        {
+            assert(OTBR_ERROR_NONE ==
+                   context.mPublisher->PublishService("UpdateService", "_meshcop._udp", 12345, "nn", "coolcool", "xp",
+                                                      "8877665544332211", NULL));
+        }
+    }
+}
+
+otbrError TestSingleService(void)
+{
+    otbrError ret = OTBR_ERROR_NONE;
+
+    Mdns::Publisher *pub = Mdns::Publisher::Create(AF_UNSPEC, NULL, NULL, PublishSingleService, &context);
+    context.mPublisher = pub;
+    SuccessOrExit(ret = pub->Start());
+    Mainloop(*pub);
+
+exit:
+    Mdns::Publisher::Destroy(pub);
+    return ret;
+}
+
+otbrError TestMultipleServices(void)
+{
+    otbrError ret = OTBR_ERROR_NONE;
+
+    Mdns::Publisher *pub = Mdns::Publisher::Create(AF_UNSPEC, NULL, NULL, PublishMultipleServices, &context);
+    context.mPublisher = pub;
+    SuccessOrExit(ret = pub->Start());
+    Mainloop(*pub);
+
+exit:
+    Mdns::Publisher::Destroy(pub);
+    return ret;
+}
+
+otbrError TestUpdateService(void)
+{
+    otbrError ret = OTBR_ERROR_NONE;
+
+    Mdns::Publisher *pub = Mdns::Publisher::Create(AF_UNSPEC, NULL, NULL, PublishUpdateServices, &context);
+    context.mPublisher = pub;
+    context.mUpdate = false;
+    SuccessOrExit(ret = pub->Start());
+    context.mUpdate = true;
+    PublishUpdateServices(&context, Mdns::kStateReady);
+    Mainloop(*pub);
+
+exit:
+    Mdns::Publisher::Destroy(pub);
+    return ret;
+}
+
+void RecoverSignal(int aSignal)
+{
+    if (aSignal == SIGUSR1)
+    {
+        signal(SIGUSR1, SIG_DFL);
+    }
+    else if (aSignal == SIGUSR2)
+    {
+        signal(SIGUSR2, SIG_DFL);
+    }
+}
+
+otbrError TestStopService(void)
+{
+    otbrError ret = OTBR_ERROR_NONE;
+
+    Mdns::Publisher *pub = Mdns::Publisher::Create(AF_UNSPEC, NULL, NULL, PublishSingleService, &context);
+    context.mPublisher = pub;
+    SuccessOrExit(ret = pub->Start());
+    signal(SIGUSR1, RecoverSignal);
+    signal(SIGUSR2, RecoverSignal);
+    Mainloop(*pub);
+    context.mPublisher->Stop();
+    Mainloop(*pub);
+    SuccessOrExit(ret = context.mPublisher->Start());
+    Mainloop(*pub);
+
+exit:
+    Mdns::Publisher::Destroy(pub);
+    return ret;
+}
+
+int main(int argc, char *argv[])
+{
+    int ret = 0;
+
+    if (argc < 2)
+    {
+        return 1;
+    }
+
+    otbrLogInit("otbr-mdns", OTBR_LOG_DEBUG);
+    switch (argv[1][0])
+    {
+    case 's':
+        ret = TestSingleService();
+        break;
+
+    case 'm':
+        ret = TestMultipleServices();
+        break;
+
+    case 'u':
+        ret = TestUpdateService();
+        break;
+
+    case 'k':
+        ret = TestStopService();
+        break;
+
+    default:
+        ret = 1;
+        break;
+    }
+
+    return ret;
+}

--- a/tests/mdns/test-multiple
+++ b/tests/mdns/test-multiple
@@ -1,3 +1,4 @@
+#!/bin/sh
 #
 #  Copyright (c) 2017, The OpenThread Authors.
 #  All rights reserved.
@@ -26,12 +27,22 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
+#
+# This script tests publishing multiple services.
+#
 
-SUBDIRS         = \
-    unit          \
-    mdns          \
-    meshcop       \
-    $(NULL)
+set -x
+set -e
 
-include $(abs_top_nlbuild_autotools_dir)/automake/post.am
+on_exit()
+{
+    kill $PID
+}
+
+./otbr-test-mdns m & PID=$!
+trap on_exit INT TERM EXIT
+
+sleep 2
+avahi-browse -aprt
+avahi-browse -aprt | grep -q 'IPv6;MultipleService1;_meshcop._udp;.\+"xp=1122334455667788.\+"nn=cool1"'
+avahi-browse -aprt | grep -q 'IPv6;MultipleService2;_meshcop._udp;.\+"xp=1122334455667788.\+"nn=cool2"'

--- a/tests/mdns/test-single
+++ b/tests/mdns/test-single
@@ -1,3 +1,4 @@
+#!/bin/sh
 #
 #  Copyright (c) 2017, The OpenThread Authors.
 #  All rights reserved.
@@ -26,12 +27,21 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
+#
+# This script tests publishing single service.
+#
 
-SUBDIRS         = \
-    unit          \
-    mdns          \
-    meshcop       \
-    $(NULL)
+set -x
+set -e
 
-include $(abs_top_nlbuild_autotools_dir)/automake/post.am
+on_exit()
+{
+    kill $PID
+}
+
+./otbr-test-mdns s & PID=$!
+trap on_exit INT TERM EXIT
+
+sleep 2
+avahi-browse -aprt
+avahi-browse -aprt | grep -q 'IPv6;SingleService;_meshcop._udp;.\+"xp=1122334455667788.\+"nn=cool"'

--- a/tests/mdns/test-stop
+++ b/tests/mdns/test-stop
@@ -1,3 +1,4 @@
+#!/bin/sh
 #
 #  Copyright (c) 2017, The OpenThread Authors.
 #  All rights reserved.
@@ -26,12 +27,33 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
+#
+# This script tests stop publishing service.
+#
 
-SUBDIRS         = \
-    unit          \
-    mdns          \
-    meshcop       \
-    $(NULL)
+set -x
+set -e
 
-include $(abs_top_nlbuild_autotools_dir)/automake/post.am
+on_exit()
+{
+    kill $PID
+}
+
+./otbr-test-mdns k & PID=$!
+trap on_exit INT TERM EXIT
+
+sleep 2
+avahi-browse -aprt
+avahi-browse -aprt | grep -q 'IPv6;SingleService;_meshcop._udp;.\+"xp=1122334455667788.\+"nn=cool"'
+
+# stop service
+kill -USR1 $PID
+sleep 1
+avahi-browse -aprt
+! avahi-browse -aprt | grep -q 'IPv6;SingleService;_meshcop._udp;.\+"xp=1122334455667788.\+"nn=cool"'
+
+# start service
+kill -USR2 $PID
+sleep 1
+avahi-browse -aprt
+avahi-browse -aprt | grep -q 'IPv6;SingleService;_meshcop._udp;.\+"xp=1122334455667788.\+"nn=cool"'

--- a/tests/mdns/test-update
+++ b/tests/mdns/test-update
@@ -1,3 +1,4 @@
+#!/bin/sh
 #
 #  Copyright (c) 2017, The OpenThread Authors.
 #  All rights reserved.
@@ -26,12 +27,21 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
+#
+# This script tests updating text record of published service.
+#
 
-SUBDIRS         = \
-    unit          \
-    mdns          \
-    meshcop       \
-    $(NULL)
+set -x
+set -e
 
-include $(abs_top_nlbuild_autotools_dir)/automake/post.am
+on_exit()
+{
+    kill $PID
+}
+
+./otbr-test-mdns u & PID=$!
+trap on_exit INT TERM EXIT
+
+sleep 2
+avahi-browse -aprt
+avahi-browse -aprt | grep -q 'IPv6;UpdateService;_meshcop._udp;.\+"xp=8877665544332211.\+"nn=coolcool"'


### PR DESCRIPTION
This PR implemented a `AvahiPoll` to integrate avahi client into `select()` based mainloop.
This is the first step to moving MDNS service from *otbr-web* into *otbr-agent*.

Functional tests are also added to make sure this service can support publishing multiple services, stop publishing as well as updating existing services.

Functional test of meshcop should be improved to use MDNS published service after it's fully moved into *otbr-agent*.