### PR TITLE
Allow web interface to connect correctly if using non-default TUN with ./console

### DIFF
--- a/script/console
+++ b/script/console
@@ -62,7 +62,7 @@ main()
 wpantund -I $TUN -s "$NCP" &
 sleep 3
 otbr-agent -I $TUN &
-otbr-web &
+otbr-web -I $TUN &
 wait
 EOF
 }


### PR DESCRIPTION
By providing the wpantund interface name as an argument.