### PR TITLE
[coap] support new message with id.

### DIFF
--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -106,7 +106,7 @@ void BorderAgent::ForwardCommissionerRequest(const Coap::Resource &aResource, co
     const uint8_t *token = aMessage.GetToken(tokenLength);
     const char    *path = aResource.mPath;
 
-    Coap::Message *message = mCoap->NewMessage(Coap::kTypeConfirmable, Coap::kCodePost,
+    Coap::Message *message = mCoap->NewMessage(Coap::kTypeConfirmable, Coap::kCodePost, aMessage.GetMessageId(),
                                                token, tokenLength);
     Ip6Address     addr(kAloc16Leader);
     uint16_t       length = 0;
@@ -185,9 +185,8 @@ void BorderAgent::HandleRelayTransmit(const Coap::Message &aMessage, const uint8
         Ip6Address     addr(rloc);
         uint8_t        tokenLength = 0;
         const uint8_t *token = aMessage.GetToken(tokenLength);
-        Coap::Message *message = mCoap->NewMessage(Coap::kTypeNonConfirmable,
-                                                   Coap::kCodePost,
-                                                   token, tokenLength);
+        Coap::Message *message = mCoap->NewMessage(Coap::kTypeNonConfirmable, Coap::kCodePost,
+                                                   aMessage.GetMessageId(), token, tokenLength);
 
         message->SetPath(OT_URI_PATH_RELAY_TX);
         message->SetPayload(payload, length);

--- a/src/agent/coap.hpp
+++ b/src/agent/coap.hpp
@@ -95,6 +95,14 @@ public:
     virtual ~Message(void) {};
 
     /**
+     * This method returns the CoAP message id of this message.
+     *
+     * @returns the CoAP message id of the message.
+     *
+     */
+    virtual uint16_t GetMessageId(void) const = 0;
+
+    /**
      * This method returns the CoAP code of this message.
      *
      * @returns the CoAP code of the message.
@@ -273,6 +281,20 @@ public:
      *
      */
     virtual Message *NewMessage(Type aType, Code aCode, const uint8_t *aToken,
+                                uint8_t aTokenLength) = 0;
+    /**
+     * This method creates a CoAP message with the given arguments.
+     *
+     * @param[in]   aType           The CoAP type.
+     * @param[in]   aCode           The CoAP code.
+     * @param[in]   aMessageId      The CoAP message id.
+     * @param[in]   aToken          The CoAP token.
+     * @param[in]   aTokenLength    Number of bytes in @p aToken.
+     *
+     * @returns The newly CoAP message.
+     *
+     */
+    virtual Message *NewMessage(Type aType, Code aCode, uint16_t aMessageId, const uint8_t *aToken,
                                 uint8_t aTokenLength) = 0;
 
     /**

--- a/src/agent/coap_libcoap.cpp
+++ b/src/agent/coap_libcoap.cpp
@@ -75,6 +75,11 @@ const uint8_t *MessageLibcoap::GetToken(uint8_t &aLength) const
     return mPdu->hdr->token;
 }
 
+uint16_t MessageLibcoap::GetMessageId(void) const
+{
+    return mPdu->hdr->id;
+}
+
 Code MessageLibcoap::GetCode(void) const
 {
     return static_cast<Code>(mPdu->hdr->code);
@@ -145,6 +150,12 @@ const uint8_t *MessageLibcoap::GetPayload(uint16_t &aLength) const
     coap_get_data(mPdu, &length, &payload);
     aLength = length;
     return payload;
+}
+
+Message *AgentLibcoap::NewMessage(Type aType, Code aCode, uint16_t aMessageId, const uint8_t *aToken,
+                                  uint8_t aTokenLength)
+{
+    return new MessageLibcoap(aType, aCode, aMessageId, aToken, aTokenLength);
 }
 
 Message *AgentLibcoap::NewMessage(Type aType, Code aCode, const uint8_t *aToken, uint8_t aTokenLength)

--- a/src/agent/coap_libcoap.hpp
+++ b/src/agent/coap_libcoap.hpp
@@ -88,6 +88,14 @@ public:
     Code GetCode(void) const;
 
     /**
+     * This method returns the CoAP message id of this message.
+     *
+     * @returns the CoAP message id of the message.
+     *
+     */
+    virtual uint16_t GetMessageId(void) const;
+
+    /**
      * This method sets the CoAP code of this message.
      *
      * @param[in]   aCode   The CoAP code.
@@ -235,6 +243,20 @@ public:
      *
      */
     Message *NewMessage(Type aType, Code aCode, const uint8_t *aToken, uint8_t aTokenLength);
+
+    /**
+     * This method creates a CoAP message with the given arguments.
+     *
+     * @param[in]   aType           The CoAP type.
+     * @param[in]   aCode           The CoAP code.
+     * @param[in]   aMessageId      The CoAP message id.
+     * @param[in]   aToken          The CoAP token.
+     * @param[in]   aTokenLength    Number of bytes in @p aToken.
+     *
+     * @returns The pointer to the newly created CoAP message.
+     *
+     */
+    Message *NewMessage(Type aType, Code aCode, uint16_t aMessageId, const uint8_t *aToken, uint8_t aTokenLength);
 
     /**
      * This method frees a CoAP message.


### PR DESCRIPTION
This PR fixes #81 by setting message id when forwarding CoAP messages from external commissioner.

Since a request from external commissioner is responded with separate response, the response message id is not overridden with the message id from Thread leader.