### PR TITLE
[script] add flags support.

### DIFF
--- a/examples/platforms/fedora/default
+++ b/examples/platforms/fedora/default
@@ -26,30 +26,5 @@
 #  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 #  POSSIBILITY OF SUCH DAMAGE.
 #
-#   Description:
-#       This script starts all border router services.
-#
 
-. "$(dirname "$0")"/_initrc
-. script/_nat64
-
-main()
-{
-    . $BEFORE_HOOK
-    sudo sysctl --system
-    nat64_start || die 'Failed to start NAT64!'
-    if have systemctl; then
-        systemctl is-active wpantund || sudo systemctl start wpantund || die 'Failed to start wpantund!'
-        systemctl is-active otbr-web || sudo systemctl start otbr-web || die 'Failed to start otbr-web!'
-        systemctl is-active otbr-agent || sudo systemctl start otbr-agent || die 'Failed to start otbr-agent!'
-    elif which service; then
-        sudo service wpantund start  || die 'Failed to start wpantund!'
-        sudo service otbr-web start || die 'Failed to start otbr-web!'
-        sudo service otbr-agent start || die 'Failed to start otbr-agent!'
-    else
-        die 'Unable to find service manager. Try script/console to start in console mode!'
-    fi
-    . $AFTER_HOOK
-}
-
-main
+NAT64=0

--- a/examples/platforms/ubuntu/default
+++ b/examples/platforms/ubuntu/default
@@ -26,30 +26,5 @@
 #  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 #  POSSIBILITY OF SUCH DAMAGE.
 #
-#   Description:
-#       This script starts all border router services.
-#
 
-. "$(dirname "$0")"/_initrc
-. script/_nat64
-
-main()
-{
-    . $BEFORE_HOOK
-    sudo sysctl --system
-    nat64_start || die 'Failed to start NAT64!'
-    if have systemctl; then
-        systemctl is-active wpantund || sudo systemctl start wpantund || die 'Failed to start wpantund!'
-        systemctl is-active otbr-web || sudo systemctl start otbr-web || die 'Failed to start otbr-web!'
-        systemctl is-active otbr-agent || sudo systemctl start otbr-agent || die 'Failed to start otbr-agent!'
-    elif which service; then
-        sudo service wpantund start  || die 'Failed to start wpantund!'
-        sudo service otbr-web start || die 'Failed to start otbr-web!'
-        sudo service otbr-agent start || die 'Failed to start otbr-agent!'
-    else
-        die 'Unable to find service manager. Try script/console to start in console mode!'
-    fi
-    . $AFTER_HOOK
-}
-
-main
+NAT64=1

--- a/script/_initrc
+++ b/script/_initrc
@@ -36,6 +36,60 @@ die()
     exit 1
 }
 
+have()
+{
+    # This function checks if a tool is available
+    #
+
+    which "$1" > /dev/null 2> /dev/null
+}
+
+have_or_die()
+{
+    # This function verifies a tool is available and dies with proper
+    # information if not available.
+    #
+
+    have "$1" || die "$1 not available!"
+}
+
+with()
+{
+    # This function verifies a flag is on.
+    #
+    # NOTE environment settings takes higher priority than default files.
+    #
+
+    VALUE=$(printenv "$1")
+    if test -z "$VALUE"; then
+        eval VALUE="\$$1"
+    fi
+
+    test "$VALUE" = 1
+}
+
+without()
+{
+    # This function verifies a flag is off.
+    #
+    # NOTE environment settings takes higher priority than default files.
+    #
+
+    ! with "$1"
+}
+
+# Platform information is needed to load hooks and default settings.
+#
+if test -z "$PLATFORM"; then
+    have_or_die lsb_release
+    PLATFORM=$(lsb_release -i | cut -c17- | tr '[:upper:]' '[:lower:]')
+fi
+echo "Current platform is $PLATFORM"
+
+if test -f examples/platforms/$PLATFORM/default; then
+    . examples/platforms/$PLATFORM/default
+fi
+
 STAGE_DIR=$(pwd)/._stage
 BUILD_DIR=$(pwd)/._build
 
@@ -44,9 +98,7 @@ BUILD_DIR=$(pwd)/._build
 
 export PATH=$STAGE_DIR/usr/bin:$STAGE_DIR/usr/sbin:$PATH
 
-PLATFORM=$(lsb_release -i | cut -c17- | tr '[:upper:]' '[:lower:]')
 TASKNAME=$(basename $0)
-echo "Current platform is $PLATFORM"
 BEFORE_HOOK=examples/platforms/$PLATFORM/before_$TASKNAME
 AFTER_HOOK=examples/platforms/$PLATFORM/after_$TASKNAME
 if test ! -f $BEFORE_HOOK; then

--- a/script/_nat64
+++ b/script/_nat64
@@ -36,8 +36,14 @@ TAYGA_IPV6_ADDR=fdaa:bb:1::1
 NAT44_SERVICE=/etc/init.d/otbr-nat44
 WLAN_IFNAMES=eth0
 
+# Currently only ubuntu is verified.
+#
+without NAT64 || test $PLATFORM = ubuntu || die "nat64 is not tested under $PLATFORM."
+
 nat64_install()
 {
+    with NAT64 || return 0
+
     test -f $TAYGA_DEFAULT -a -f $TAYGA_CONF || die 'Cannot find tayga configuration file!'
     sudo sed -i 's/^RUN="no"/RUN="yes"/' $TAYGA_DEFAULT
     sudo sed -i 's/^prefix /##prefix /' $TAYGA_CONF
@@ -110,7 +116,7 @@ EOF
 esac
 EOF
     sudo chmod a+x $NAT44_SERVICE
-    if which systemctl; then
+    if have systemctl; then
         sudo systemctl stop tayga || die 'Unable to stop tayga service!'
         sudo systemctl enable otbr-nat44 || die 'Unable to enable nat44 service!'
     fi
@@ -118,18 +124,20 @@ EOF
 
 nat64_uninstall()
 {
+    with NAT64 || return 0
+
     nat64_stop
     sudo sed -i 's/^RUN="yes"/RUN="no"/' $TAYGA_DEFAULT
     sudo sed -i 's/^prefix 64:ff9b::\/96/# prefix 64:ff9b::\/96/' $TAYGA_CONF
     sudo sed -i 's/^##prefix /prefix /' $TAYGA_CONF
     sudo sed -i '/^ipv6-addr '$TAYGA_IPV6_ADDR'/d' $TAYGA_CONF
 
-    if which systemctl; then
+    if have systemctl; then
         sudo systemctl disable otbr-nat44 || true
     fi
 
     # systemctl disable doesn't remove sym-links
-    if which update-rc.d; then
+    if have update-rc.d; then
         sudo update-rc.d otbr-nat44 remove || true
     fi
     test ! -f $NAT44_SERVICE || sudo rm $NAT44_SERVICE
@@ -137,7 +145,9 @@ nat64_uninstall()
 
 nat64_start()
 {
-    if which systemctl; then
+    with NAT64 || return 0
+
+    if have systemctl; then
         sudo systemctl start tayga || die 'Failed to start tayga!'
         sudo systemctl start otbr-nat44 || die 'Failed to start NAT44!'
     fi
@@ -145,7 +155,9 @@ nat64_start()
 
 nat64_stop()
 {
-    if which systemctl; then
+    with NAT64 || return 0
+
+    if have systemctl; then
         sudo systemctl stop tayga || true
         sudo systemctl stop otbr-nat44 || true
     fi

--- a/script/_otbr
+++ b/script/_otbr
@@ -29,7 +29,7 @@
 
 otbr_uninstall()
 {
-    if which systemctl; then
+    if have systemctl; then
         sudo systemctl stop otbr-web otbr-agent wpantund || true
         sudo systemctl disable otbr-web otbr-agent wpantund || true
         ! sudo systemctl is-enabled otbr-web
@@ -39,7 +39,7 @@ otbr_uninstall()
     sudo killall otbr-web otbr-agent || true
 
     test ! -f config.status || sudo make uninstall
-    if which systemctl; then
+    if have systemctl; then
         sudo systemctl daemon-reload
     fi
 }
@@ -49,7 +49,7 @@ otbr_install()
     test -f config.status || ./configure --prefix=/usr --sysconfdir=/etc
     make -j$(getconf _NPROCESSORS_ONLN)
     sudo make install
-    if which systemctl; then
+    if have systemctl; then
         sudo systemctl reload dbus
         sudo systemctl daemon-reload
         sudo systemctl enable wpantund otbr-web otbr-agent || true

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -37,7 +37,7 @@ install_packages_apt()
     sudo apt-get update
     sudo apt-get install -y build-essential libtool git
 
-    test "$RELEASE" = 1 || sudo apt-get install -y cmake
+    with RELEASE || sudo apt-get install -y cmake
 
     # For wpantund
     sudo apt-get install -y libdbus-1-dev
@@ -60,7 +60,7 @@ install_packages_apt()
     sudo apt-get install -y libboost-dev libboost-filesystem-dev libboost-system-dev
 
     # nat64
-    sudo apt-get install -y tayga iptables
+    without NAT64 || sudo apt-get install -y tayga iptables
 
     # libjsoncpp
     sudo apt-get install -y libjsoncpp-dev
@@ -68,34 +68,34 @@ install_packages_apt()
 
 install_packages_opkg()
 {
-    echo 'opkg not supported currently' && false
+    die 'opkg not supported currently'
 }
 
 install_packages_rpm()
 {
-    echo 'rpm not supported currently' && false
+    die 'rpm not supported currently'
 }
 
 install_packages_brew()
 {
-    echo 'macOS not supported currently' && false
+    die 'macOS not supported currently'
 }
 
 install_packages_source()
 {
-    echo 'source not supported currently' && false
+    die 'source not supported currently'
 }
 
 install_packages()
 {
     PM=source
-    if which apt-get; then
+    if have apt-get; then
         PM=apt
-    elif which rpm; then
+    elif have rpm; then
         PM=rpm
-    elif which opkg; then
+    elif have opkg; then
         PM=opkg
-    elif which brew; then
+    elif have brew; then
         PM=brew
     fi
     install_packages_$PM
@@ -145,8 +145,8 @@ main()
 {
     . $BEFORE_HOOK
     install_packages
-    test "$RELEASE" = 1 || install_uncrustify
-    test "$RELEASE" = 1 || install_cpputest
+    with RELEASE || install_uncrustify
+    with RELEASE || install_cpputest
     ./bootstrap
     . $AFTER_HOOK
 }

--- a/script/console
+++ b/script/console
@@ -51,7 +51,7 @@ on_exit()
 main()
 {
     . $BEFORE_HOOK
-    if which systemctl; then
+    if have systemctl; then
         sudo systemctl stop otbr-web otbr-agent wpantund || true
     fi
     killall_services


### PR DESCRIPTION
This PR solves #79 by adding a flag mechanism to tune the behavior of scripts.

Every platform can provide default flag settings in `examples/platforms/$PLATFORM/default`. Flag settings can be override by environment variables. `PLATFORM` is by default detected based on output of `lsb_release`, but it can also be set by environment variable.

Currently supported flags
```
NAT64
RELEASE
```