### PR TITLE
[code] fix warnings.

### DIFF
--- a/src/agent/agent_instance.cpp
+++ b/src/agent/agent_instance.cpp
@@ -87,9 +87,9 @@ void AgentInstance::FeedCoap(void *aContext, int aEvent, va_list aArguments)
 
     AgentInstance *agentInstance = static_cast<AgentInstance *>(aContext);
     const uint8_t *buffer = va_arg(aArguments, const uint8_t *);
-    uint16_t       length = va_arg(aArguments, int);
-    uint16_t       locator = va_arg(aArguments, int);
-    uint16_t       port = va_arg(aArguments, int);
+    uint16_t       length = static_cast<uint16_t>(va_arg(aArguments, unsigned int));
+    uint16_t       locator = static_cast<uint16_t>(va_arg(aArguments, unsigned int));
+    uint16_t       port = static_cast<uint16_t>(va_arg(aArguments, unsigned int));
     Ip6Address     addr(locator);
 
     agentInstance->mCoap->Input(buffer, length, addr.m8, port);

--- a/src/agent/coap_libcoap.cpp
+++ b/src/agent/coap_libcoap.cpp
@@ -143,7 +143,7 @@ const uint8_t *MessageLibcoap::GetPayload(uint16_t &aLength) const
     size_t   length = 0;
 
     coap_get_data(mPdu, &length, &payload);
-    aLength = length;
+    aLength = static_cast<uint16_t>(length);
     return payload;
 }
 
@@ -347,7 +347,7 @@ AgentLibcoap::AgentLibcoap(NetworkSender aNetworkSender, void *aContext)
 
     time_t clock_offset = time(NULL);
     memset(&mCoap, 0, sizeof(mCoap));
-    prng_init(reinterpret_cast<unsigned long>(aNetworkSender) ^ clock_offset);
+    prng_init(reinterpret_cast<unsigned long>(aNetworkSender) ^ static_cast<unsigned long>(clock_offset));
     prng(reinterpret_cast<unsigned char *>(&mCoap.message_id), sizeof(unsigned short));
 
     coap_address_t addr;
@@ -368,7 +368,7 @@ ssize_t AgentLibcoap::NetworkSend(coap_context_t *aCoap,
 
     AgentLibcoap *agent = static_cast<AgentLibcoap *>(CONTAINING_RECORD(aCoap, AgentLibcoap, mCoap));
 
-    return agent->mNetworkSender(aBuffer, aLength,
+    return agent->mNetworkSender(aBuffer, static_cast<uint16_t>(aLength),
                                  reinterpret_cast<const uint8_t *>(&aDestination->addr.sin6.sin6_addr),
                                  ntohs(aDestination->addr.sin6.sin6_port), agent->mContext);
 }

--- a/src/agent/dtls_mbedtls.cpp
+++ b/src/agent/dtls_mbedtls.cpp
@@ -415,8 +415,8 @@ exit:
 void MbedtlsServer::UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, fd_set &aErrorFdSet, int &aMaxFd,
                                 timeval &aTimeout)
 {
-    uint64_t now = GetNow();
-    uint64_t timeout = aTimeout.tv_sec * 1000 + aTimeout.tv_sec / 1000;
+    unsigned long now = GetNow();
+    unsigned long timeout = static_cast<unsigned long>(aTimeout.tv_sec * 1000 + aTimeout.tv_sec / 1000);
 
     for (SessionSet::iterator it = mSessions.begin();
          it != mSessions.end(); )
@@ -433,8 +433,7 @@ void MbedtlsServer::UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, fd_set 
         else if (session->GetState() == Session::kStateReady ||
                  session->GetState() == Session::kStateHandshaking)
         {
-            int      fd = session->GetFd();
-            uint64_t sessionTimeout = session->GetExpiration() - now;
+            int fd = session->GetFd();
 
             otbrLog(OTBR_LOG_INFO, "DTLS session[%d] alive.", fd);
             FD_SET(fd, &aReadFdSet);
@@ -444,9 +443,9 @@ void MbedtlsServer::UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, fd_set 
                 aMaxFd = fd;
             }
 
-            if (sessionTimeout < timeout)
+            if (static_cast<long>(session->GetExpiration() - (now + timeout)) < 0)
             {
-                timeout = sessionTimeout;
+                timeout = static_cast<unsigned long>(session->GetExpiration() - now);
             }
 
             // TODO error set

--- a/src/agent/dtls_mbedtls.hpp
+++ b/src/agent/dtls_mbedtls.hpp
@@ -208,7 +208,7 @@ private:
     sockaddr_in6                 mRemoteSock;
     sockaddr_in6                 mLocalSock;
     MbedtlsServer               &mServer;
-    uint64_t                     mExpiration;
+    unsigned long                mExpiration;
     uint8_t                      mKek[kKekSize];
 };
 

--- a/src/agent/mdns.hpp
+++ b/src/agent/mdns.hpp
@@ -105,7 +105,7 @@ public:
      * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the service.
      *
      */
-    virtual otbrError PublishService(const char *aName, const char *aType, uint16_t aPort, ...) = 0;
+    virtual otbrError PublishService(uint16_t aPort, const char *aName, const char *aType, ...) = 0;
 
     /**
      * This method performs the MDNS processing.

--- a/src/agent/mdns_avahi.hpp
+++ b/src/agent/mdns_avahi.hpp
@@ -94,7 +94,7 @@ struct AvahiWatch
  */
 struct AvahiTimeout
 {
-    uint64_t             mTimeout;  ///< Absolute time when this timer timeout.
+    unsigned long        mTimeout;  ///< Absolute time when this timer timeout.
     AvahiTimeoutCallback mCallback; ///< The function to be called when timeout.
     void                *mContext;  ///< The pointer to application-specific context.
     void                *mPoller;   ///< The poller created this timer.
@@ -225,7 +225,7 @@ public:
      * @retval  OTBR_ERROR_ERRNO    Failed to publish or update the service.
      *
      */
-    otbrError PublishService(const char *aName, const char *aType, uint16_t aPort, ...);
+    otbrError PublishService(uint16_t aPort, const char *aName, const char *aType, ...);
 
     /**
      * This method starts the MDNS service.

--- a/src/agent/ncp_wpantund.cpp
+++ b/src/agent/ncp_wpantund.cpp
@@ -387,12 +387,12 @@ void ControllerWpantund::Process(const fd_set &aReadFdSet, const fd_set &aWriteF
 
         if ((flags & DBUS_WATCH_READABLE) && !FD_ISSET(fd, &aReadFdSet))
         {
-            flags &= ~DBUS_WATCH_READABLE;
+            flags &= static_cast<unsigned int>(~DBUS_WATCH_READABLE);
         }
 
         if ((flags & DBUS_WATCH_WRITABLE) && !FD_ISSET(fd, &aWriteFdSet))
         {
-            flags &= ~DBUS_WATCH_WRITABLE;
+            flags &= static_cast<unsigned int>(~DBUS_WATCH_WRITABLE);
         }
 
         if (FD_ISSET(fd, &aErrorFdSet))
@@ -502,7 +502,7 @@ otbrError ControllerWpantund::GetProperty(const char *aKey, uint8_t *aBuffer, si
                      errno = EINVAL);
 
         aSize = static_cast<size_t>(count);
-        memcpy(aBuffer, buffer, count);
+        memcpy(aBuffer, buffer, aSize);
     }
 
     ret = OTBR_ERROR_NONE;

--- a/src/common/code_utils.hpp
+++ b/src/common/code_utils.hpp
@@ -39,7 +39,7 @@
  *
  */
 #define OTBR_ALIGNED(aMem, aAlignType)                                      \
-    reinterpret_cast<aAlignType>((((long)(aMem) + sizeof(aAlignType) - 1) / \
+    reinterpret_cast<aAlignType>(((reinterpret_cast<unsigned long>(aMem) + sizeof(aAlignType) - 1) / \
                                   sizeof(aAlignType)) * sizeof(aAlignType))
 
 #ifndef CONTAINING_RECORD

--- a/src/common/time.hpp
+++ b/src/common/time.hpp
@@ -46,9 +46,9 @@ namespace BorderRouter {
  * @returns timestamp in miniseconds.
  *
  */
-inline uint64_t GetTimestamp(const timeval &aTime)
+inline unsigned long GetTimestamp(const timeval &aTime)
 {
-    return aTime.tv_sec * 1000 + aTime.tv_usec / 1000;
+    return static_cast<unsigned long>(aTime.tv_sec * 1000 + aTime.tv_usec / 1000);
 }
 
 /**
@@ -57,11 +57,11 @@ inline uint64_t GetTimestamp(const timeval &aTime)
  * @returns Current timestamp in miniseconds.
  *
  */
-inline uint64_t GetNow(void) {
+inline unsigned long GetNow(void) {
     timeval now;
 
     gettimeofday(&now, NULL);
-    return now.tv_sec * 1000 + now.tv_usec / 1000;
+    return static_cast<unsigned long>(now.tv_sec * 1000 + now.tv_usec / 1000);
 }
 
 } // namespace BorderRouter

--- a/src/common/tlv.hpp
+++ b/src/common/tlv.hpp
@@ -73,7 +73,8 @@ public:
      *
      */
     uint16_t GetLength(void) const {
-        return (mLength != kLengthEscape ? mLength : ((&mLength)[1] << 8 | (&mLength)[2]));
+        return (mLength != kLengthEscape ? mLength :
+                static_cast<uint16_t>((&mLength)[1] << 8 | (&mLength)[2]));
     }
 
     /**
@@ -112,7 +113,7 @@ public:
     uint16_t GetValueUInt16(void) const {
         const uint8_t *p = static_cast<const uint8_t *>(GetValue());
 
-        return (p[0] << 8 | p[1]);
+        return static_cast<uint16_t>(p[0] << 8 | p[1]);
     }
 
     /**

--- a/src/common/types.hpp
+++ b/src/common/types.hpp
@@ -104,7 +104,7 @@ public:
      */
     uint16_t ToLocator(void) const
     {
-        return (m8[14] << 8 | m8[15]);
+        return static_cast<uint16_t>(m8[14] << 8 | m8[15]);
     }
 
     union

--- a/tests/mdns/main.cpp
+++ b/tests/mdns/main.cpp
@@ -86,7 +86,7 @@ void PublishSingleService(void *aContext, Mdns::State aState)
     if (aState == Mdns::kStateReady)
     {
         assert(OTBR_ERROR_NONE ==
-               context.mPublisher->PublishService("SingleService", "_meshcop._udp", 12345, "nn", "cool", "xp",
+               context.mPublisher->PublishService(12345, "SingleService", "_meshcop._udp", "nn", "cool", "xp",
                                                   "1122334455667788", NULL));
     }
 }
@@ -98,10 +98,10 @@ void PublishMultipleServices(void *aContext, Mdns::State aState)
     if (aState == Mdns::kStateReady)
     {
         assert(OTBR_ERROR_NONE ==
-               context.mPublisher->PublishService("MultipleService1", "_meshcop._udp", 12345, "nn", "cool1", "xp",
+               context.mPublisher->PublishService(12345, "MultipleService1", "_meshcop._udp", "nn", "cool1", "xp",
                                                   "1122334455667788", NULL));
         assert(OTBR_ERROR_NONE ==
-               context.mPublisher->PublishService("MultipleService2", "_meshcop._udp", 12346, "nn", "cool2", "xp",
+               context.mPublisher->PublishService(12346, "MultipleService2", "_meshcop._udp", "nn", "cool2", "xp",
                                                   "1122334455667788", NULL));
     }
 }
@@ -115,13 +115,13 @@ void PublishUpdateServices(void *aContext, Mdns::State aState)
         if (!context.mUpdate)
         {
             assert(OTBR_ERROR_NONE ==
-                   context.mPublisher->PublishService("UpdateService", "_meshcop._udp", 12345, "nn", "cool", "xp",
+                   context.mPublisher->PublishService(12345, "UpdateService", "_meshcop._udp", "nn", "cool", "xp",
                                                       "1122334455667788", NULL));
         }
         else
         {
             assert(OTBR_ERROR_NONE ==
-                   context.mPublisher->PublishService("UpdateService", "_meshcop._udp", 12345, "nn", "coolcool", "xp",
+                   context.mPublisher->PublishService(12345, "UpdateService", "_meshcop._udp", "nn", "coolcool", "xp",
                                                       "8877665544332211", NULL));
         }
     }

--- a/third_party/mbedtls/Makefile.am
+++ b/third_party/mbedtls/Makefile.am
@@ -29,6 +29,7 @@
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
 lib_LTLIBRARIES=libmbedtls.la
+override CFLAGS:=$(filter-out -Wconversion,$(CFLAGS)) -Wno-overlength-strings
 
 libmbedtls_la_SOURCES                   = \
     repo/library/aes.c                    \


### PR DESCRIPTION
This PR fixes,
* signed conversion warnings when enabled `-Wsign-conversion`, which is forced under some environment.
* `va_start` warning for now starting from promoted type argument.
* changed return type of `GetNow()` to `unsigned long`.