### PR TITLE
[tests] remove hardcoding for commissioner test app

### DIFF
--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -90,6 +90,8 @@ void BorderAgent::ForwardCommissionerResponse(const Coap::Message &aMessage)
     Coap::Code     code = aMessage.GetCode();
     Coap::Message *message = mCoaps->NewMessage(Coap::kTypeNonConfirmable, code, token, tokenLength);
 
+    otbrLog(OTBR_LOG_INFO, "Forwarding CommissionerResponse ...");
+
     payload = aMessage.GetPayload(length);
     message->SetPayload(payload, length);
 
@@ -145,6 +147,8 @@ void BorderAgent::HandleRelayReceive(const Coap::Message &aMessage, const uint8_
 
     Coap::Message *message = mCoaps->NewMessage(Coap::kTypeNonConfirmable, Coap::kCodePost,
                                                 token, tokenLength);
+    otbrLog(OTBR_LOG_INFO, "Handle Relay receive ...");
+
     message->SetPath(OT_URI_PATH_RELAY_RX);
     message->SetPayload(payload, length);
 

--- a/src/agent/dtls_mbedtls.cpp
+++ b/src/agent/dtls_mbedtls.cpp
@@ -77,8 +77,31 @@ static void MbedtlsDebug(void *aContext, int aLevel, const char *aFile, int aLin
         aLevel = OTBR_LOG_DEBUG;
         break;
     }
+    char buf[100];
+    /* mbed inserts a EOL
+     * And so does the otbrLog()
+     * remove that here.
+     */
 
-    otbrLog(aLevel, "%s:%04d: %s", aFile, aLine, aMessage);
+    /* make a copy because we modify it */
+    strncpy(buf, aMessage, sizeof(buf) - 1);
+    /* force termination */
+    buf[sizeof(buf) - 1] = 0;
+
+    /* now remove the extra cr/lf */
+    char *cp;
+    cp = strchr(buf, '\n');
+    if (cp)
+    {
+        *cp = 0;
+    }
+    cp = strchr(buf, '\r');
+    if (cp)
+    {
+        *cp = 0;
+    }
+
+    otbrLog(aLevel, "%s:%04d: %s", aFile, aLine, buf);
     (void)aContext;
 }
 

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -148,6 +148,11 @@ static void log_str(const char *cp)
             log_col0 = true;
         }
         fputc(ch, log_fp);
+        if (ch == '\n')
+        {
+	    /* force flush (in case something crashes) */
+            fflush(log_fp);
+        }
     }
 }
 

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -28,64 +28,267 @@
 
 #include "logging.hpp"
 
+#include <stdlib.h>
+#include <stdio.h>
 #include <assert.h>
 #include <errno.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <string.h>
 #include <syslog.h>
+#include <sys/time.h>
 
 static int        sLevel = LOG_INFO;
 static const char HEX_CHARS[] = "0123456789abcdef";
 
+static unsigned msecs_start;
+static bool     log_col0 = true; /* we start at col0 */
+static FILE    *log_fp;
+static bool     syslog_enabled = true;
+static bool     syslog_opened = false;
+
+#define LOGFLAG_syslog 1
+#define LOGFLAG_file   2
+
+/** Set/Clear syslog enable flag */
+void otbrLogEnableSyslog(bool b)
+{
+    syslog_enabled = b;
+}
+
+/** Enable logging to a specific file */
+void otbrLogSetFilename(const char *filename)
+{
+    log_fp = fopen(filename, "w");
+    if (log_fp == NULL)
+    {
+        fprintf(stderr, "Cannot open log file: %s\n", filename);
+        perror(filename);
+        exit(EXIT_FAILURE);
+    }
+}
+
+/** Get the current debug log level */
+int  otbrLogGetLevel(void)
+{
+    return sLevel;
+}
+
+/** Set the debug log level */
+void otbrLogSetLevel(int aLevel)
+{
+    assert(aLevel >= LOG_EMERG && aLevel <= LOG_DEBUG);
+    sLevel = aLevel;
+}
+
+/** Determine if we should not or not log, and if so where to */
+static int do_log(int aLevel)
+{
+    int r;
+
+    assert(aLevel >= LOG_EMERG && aLevel <= LOG_DEBUG);
+
+    r = 0;
+
+    if (syslog_opened && syslog_enabled && (aLevel >= sLevel))
+    {
+        r = r | LOGFLAG_syslog;
+    }
+
+    /* if someone has turned on the seperate file the most likely
+     * situation is they are debugging a problem, or need a extra
+     * information. In this case, we do not test the log level.
+     */
+    if (log_fp != NULL)
+    {
+        r = r | LOGFLAG_file;
+    }
+    return r;
+}
+
+
+/** return the time, in milliseconds since application start */
+static unsigned msecs_now(void)
+{
+    struct timeval tv;
+    uint64_t       v;
+
+    gettimeofday(&tv, NULL);
+
+    v = tv.tv_sec;
+    v = v * 1000;
+    v = v + (tv.tv_usec / 1000);
+
+    if (msecs_start == 0)
+    {
+        msecs_start = (unsigned)(v);
+    }
+    v = v - msecs_start;
+    return v;
+}
+
+
+/** Write this string to the private log file, inserting the timestamp at column 0 */
+static void log_str(const char *cp)
+{
+    int ch;
+
+    while ((ch = *cp++) != 0)
+    {
+        if (log_col0)
+        {
+            log_col0 = false;
+            unsigned n;
+            n = msecs_now();
+            fprintf(log_fp, "%4d.%03d | ", (n / 1000), (n % 1000));
+        }
+        if (ch == '\n')
+        {
+            log_col0 = true;
+        }
+        fputc(ch, log_fp);
+    }
+}
+
+/** Print to the private log file */
+static void log_vprintf(const char *fmt, va_list ap)
+{
+    char buf[1024];
+
+    /* if not enabled ... leave */
+    if (log_fp == NULL)
+    {
+        return;
+    }
+    vsnprintf(buf, sizeof(buf), fmt, ap);
+
+    log_str(buf);
+}
+
+/** Print to the private log file */
+static void log_printf(const char *fmt, ...)
+{
+    va_list ap;
+
+    va_start(ap, fmt);
+    log_vprintf(fmt, ap);
+    va_end(ap);
+}
+
+
+/** Initialize logging */
 void otbrLogInit(const char *aIdent, int aLevel)
 {
     assert(aIdent);
     assert(aLevel >= LOG_EMERG && aLevel <= LOG_DEBUG);
 
-    openlog(aIdent, LOG_CONS | LOG_PID | LOG_PERROR, LOG_USER);
+    /* only open the syslog once... */
+    if (!syslog_opened)
+    {
+        syslog_opened = true;
+        openlog(aIdent, LOG_CONS | LOG_PID | LOG_PERROR, LOG_USER);
+    }
     sLevel = aLevel;
 }
 
+/** log to the syslog or log file */
 void otbrLog(int aLevel, const char *aFormat, ...)
 {
-    assert(aFormat);
-    assert(aLevel >= LOG_EMERG && aLevel <= LOG_DEBUG);
+    va_list ap;
 
-    if (aLevel > sLevel)
-    {
-        return;
-    }
-
-    va_list args;
-    va_start(args, aFormat);
-    vsyslog(aLevel, aFormat, args);
-    va_end(args);
+    va_start(ap, aFormat);
+    otbrLogv(aLevel, aFormat, ap);
+    va_end(ap);
 }
 
+/** log to the syslog or log file */
+void otbrLogv(int aLevel, const char *aFormat, va_list ap)
+{
+    int r;
+
+    assert(aFormat);
+
+    r = do_log(aLevel);
+
+
+    if (r & LOGFLAG_file)
+    {
+        va_list cpy;
+        va_copy(cpy, ap);
+        log_vprintf(aFormat, cpy);
+        va_end(cpy);
+
+        /* logs do not end with a NEWLINE, we add one here */
+        log_str("\n");
+    }
+
+    if (r & LOGFLAG_syslog)
+    {
+        vsyslog(aLevel, aFormat, ap);
+    }
+}
+
+/** Hex dump data to the log */
 void otbrDump(int aLevel, const char *aPrefix, const void *aMemory, size_t aSize)
 {
     assert(aPrefix && aMemory);
-    assert(aLevel >= LOG_EMERG && aLevel <= LOG_DEBUG);
+    const uint8_t *pEnd;
+    const uint8_t *p8;
+    int            r;
+    int            addr;
 
-    if (aLevel > sLevel)
+    r = do_log(aLevel);
+    if (r == 0)
     {
         return;
     }
 
-    char *hex = new char[aSize * 2 + 1];
-    char *ch = hex - 1;
 
-    for (const uint8_t *mem = static_cast<const uint8_t *>(aMemory), *end = mem + aSize;
-         mem != end; ++mem)
+    /* break hex dumps into 16byte lines
+     * In the form ADDR: XX XX XX XX ...
+     */
+
+    p8 = (const uint8_t *)(aMemory);
+
+    // we pre-increment... so subtract
+    p8 = p8 - 16;
+    addr = -16;
+
+    while (aSize > 0)
     {
-        *++ch = HEX_CHARS[(*mem) >> 4];
-        *++ch = HEX_CHARS[(*mem) & 0x0f];
-    }
-    hex[aSize * 2] = 0;
+        size_t this_size;
+        char   hex[16 * 3 + 1];
 
-    syslog(aLevel, "%s #%zu %s", aPrefix, aSize, hex);
-    delete[] hex;
+        addr = addr + 16;
+        p8 = p8   + 16;
+
+        /* truncate line to max 16 bytes */
+        this_size = aSize;
+        if (this_size > 16)
+        {
+            this_size = 16;
+        }
+        aSize = aSize - this_size;
+
+        char *ch = hex - 1;
+        pEnd = p8 + this_size;
+        while (p8 < pEnd)
+        {
+            *++ch = HEX_CHARS[(*p8) >> 4];
+            *++ch = HEX_CHARS[(*p8) & 0x0f];
+            p8++;
+        }
+        *ch = 0;
+
+        if (r & LOGFLAG_syslog)
+        {
+            syslog(aLevel, "%s: %04x: %s", aPrefix, addr, hex);
+        }
+        if (r & LOGFLAG_file)
+        {
+            log_printf("%s: %04x: %s\n", aPrefix, addr, hex);
+        }
+    }
 }
 
 const char *otbrErrorString(otbrError aError)

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -60,10 +60,10 @@ void otbrLogEnableSyslog(bool b)
 /** Enable logging to a specific file */
 void otbrLogSetFilename(const char *filename)
 {
-    if( sLogFp )
+    if (sLogFp)
     {
-	fclose(sLogFp);
-	sLogFp = NULL;
+        fclose(sLogFp);
+        sLogFp = NULL;
     }
     sLogFp = fopen(filename, "w");
     if (sLogFp == NULL)
@@ -190,7 +190,7 @@ static void LogPrintf(const char *fmt, ...)
 /** Initialize logging */
 void otbrLogInit(const char *aIdent, int aLevel)
 {
-    
+
     assert(aIdent);
     assert(aLevel >= LOG_EMERG && aLevel <= LOG_DEBUG);
 

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -60,6 +60,11 @@ void otbrLogEnableSyslog(bool b)
 /** Enable logging to a specific file */
 void otbrLogSetFilename(const char *filename)
 {
+    if( sLogfp )
+    {
+	fclose(sLogFp);
+	sLogFp = NULL;
+    }
     sLogFp = fopen(filename, "w");
     if (sLogFp == NULL)
     {
@@ -109,7 +114,7 @@ static int LogCheck(int aLevel)
 
 
 /** return the time, in milliseconds since application start */
-static unsigned msecs_now(void)
+static unsigned LogMsecsNow(void)
 {
     struct timeval tv;
     uint64_t       v;
@@ -140,7 +145,7 @@ static void LogString(const char *cp)
         {
             sLogCol0 = false;
             unsigned n;
-            n = msecs_now();
+            n = LogMsecsNow();
             fprintf(sLogFp, "%4d.%03d | ", (n / 1000), (n % 1000));
         }
         if (ch == '\n')
@@ -185,8 +190,12 @@ static void LogPrintf(const char *fmt, ...)
 /** Initialize logging */
 void otbrLogInit(const char *aIdent, int aLevel)
 {
+    
     assert(aIdent);
     assert(aLevel >= LOG_EMERG && aLevel <= LOG_DEBUG);
+
+    /* call to init the msec epoch value */
+    LogMsecsNow();
 
     /* only open the syslog once... */
     if (!sSyslogOpened)

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -60,7 +60,7 @@ void otbrLogEnableSyslog(bool b)
 /** Enable logging to a specific file */
 void otbrLogSetFilename(const char *filename)
 {
-    if( sLogfp )
+    if( sLogFp )
     {
 	fclose(sLogFp);
 	sLogFp = NULL;

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -150,7 +150,7 @@ static void log_str(const char *cp)
         fputc(ch, log_fp);
         if (ch == '\n')
         {
-	    /* force flush (in case something crashes) */
+            /* force flush (in case something crashes) */
             fflush(log_fp);
         }
     }

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -75,7 +75,7 @@ void otbrLogSetFilename(const char *filename)
 }
 
 /** Get the current debug log level */
-int  otbrLogGetLevel(void)
+int otbrLogGetLevel(void)
 {
     return sLevel;
 }

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -270,11 +270,11 @@ void otbrDump(int aLevel, const char *aPrefix, const void *aMemory, size_t aSize
 
         char *ch = hex - 1;
 
-	for( pEnd = p8 + this_size ; p8 < pEnd ; p8++ )
+        for (pEnd = p8 + this_size; p8 < pEnd; p8++)
         {
             *++ch = HEX_CHARS[(*p8) >> 4];
             *++ch = HEX_CHARS[(*p8) & 0x0f];
-	    *++ch = ' ';
+            *++ch = ' ';
         }
         *ch = 0;
 

--- a/src/common/logging.hpp
+++ b/src/common/logging.hpp
@@ -30,7 +30,7 @@
 #define LOGGING_HPP_
 
 #include <stddef.h>
-
+#include <stdarg.h>
 #include "types.hpp"
 
 /**
@@ -50,6 +50,34 @@ enum
 };
 
 /**
+ * Change the log level
+ *
+ * @param[in]   alevel  new log level
+ */
+
+void otbrLogSetLevel(int aLevel);
+
+
+/**
+ * Get current log level
+ */
+int otbrLogGetLevel(void);
+
+/**
+ * Control log to syslog
+ *
+ * @param[in] enable true to log to/via syslog
+ *
+ */
+void otbrLogEnableSyslog(bool enabled);
+
+/**
+ * This function causes logs to be written to a specific file
+ * Note: Logs are still written to the syslog.
+ */
+void otbrLogSetFilename(const char *filename);
+
+/**
  * This function initialize the logging service.
  *
  * @param[in]   aIdent  Identity of the logger.
@@ -66,6 +94,15 @@ void otbrLogInit(const char *aIdent, int aLevel);
  *
  */
 void otbrLog(int aLevel, const char *aFormat, ...);
+
+/**
+ * This function log at level @p aLevel.
+ *
+ * @param[in]   aLevel  Log level of the logger.
+ * @param[in]   aFormat Format string as in printf.
+ *
+ */
+void otbrLogv(int aLevel, const char *aFormat, va_list);
 
 /**
  * This function dump memory as hex string at level @p aLevel.

--- a/src/common/logging.hpp
+++ b/src/common/logging.hpp
@@ -69,13 +69,15 @@ int otbrLogGetLevel(void);
  * @param[in] enable true to log to/via syslog
  *
  */
-void otbrLogEnableSyslog(bool enabled);
+void otbrLogEnableSyslog(bool aEnabled);
 
 /**
  * This function causes logs to be written to a specific file
  * Note: Logs are still written to the syslog.
+ *
+ * @param[in] afilename filename to use for private logfile.
  */
-void otbrLogSetFilename(const char *filename);
+void otbrLogSetFilename(const char *aFilename);
 
 /**
  * This function initialize the logging service.

--- a/src/utils/Makefile.am
+++ b/src/utils/Makefile.am
@@ -31,11 +31,15 @@ include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 noinst_LTLIBRARIES = libutils.la
 
 libutils_la_SOURCES = \
+    crc16.cpp         \
     hex.cpp           \
+    steeringdata.cpp  \
     $(NULL)
 
 noinst_HEADERS     = \
+    crc16.hpp        \
     hex.hpp          \
+    steeringdata.hpp \
     $(NULL)
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/utils/crc16.cpp
+++ b/src/utils/crc16.cpp
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2016, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements CRC16 computations.
+ */
+
+#include "crc16.hpp"
+
+namespace ot {
+
+Crc16::Crc16(Polynomial aPolynomial)
+{
+    mPolynomial = static_cast<uint16_t>(aPolynomial);
+    Init();
+}
+
+void Crc16::Update(uint8_t aByte)
+{
+    uint8_t i;
+
+    mCrc = mCrc ^ static_cast<uint16_t>(aByte << 8);
+    i = 8;
+
+    do
+    {
+        if (mCrc & 0x8000)
+        {
+            mCrc = static_cast<uint16_t>(mCrc << 1) ^ mPolynomial;
+        }
+        else
+        {
+            mCrc = static_cast<uint16_t>(mCrc << 1);
+        }
+    }
+    while (--i);
+}
+
+} // namespace ot

--- a/src/utils/crc16.hpp
+++ b/src/utils/crc16.hpp
@@ -1,0 +1,91 @@
+/*
+ *  Copyright (c) 2016, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for CRC16 computations.
+ */
+
+#ifndef CRC16_HPP_
+#define CRC16_HPP_
+
+#include <stdint.h>
+
+namespace ot {
+
+/**
+ * This class implements CRC16 computations.
+ *
+ */
+class Crc16
+{
+public:
+    enum Polynomial
+    {
+        kCcitt = 0x1021, ///< CRC16_CCITT
+        kAnsi  = 0x8005, ///< CRC16-ANSI
+    };
+
+    /**
+     * This constructor initializes the object.
+     *
+     * @param[in]  aPolynomial  The polynomial value.
+     *
+     */
+    Crc16(Polynomial aPolynomial);
+
+    /**
+     * This method initializes the CRC16 computation.
+     *
+     */
+    void Init(void) { mCrc = 0; }
+
+    /*c*
+     * This method feeds a byte value into the CRC16 computation.
+     *
+     * @param[in]  aByte  The byte value.
+     *
+     */
+    void Update(uint8_t aByte);
+
+    /**
+     * This method gets the current CRC16 value.
+     *
+     * @returns The current CRC16 value.
+     *
+     */
+    uint16_t Get(void) const { return mCrc; }
+
+private:
+    uint16_t mPolynomial;
+    uint16_t mCrc;
+};
+
+} // namespace ot
+
+#endif  // CRC16_HPP_

--- a/src/utils/steeringdata.cpp
+++ b/src/utils/steeringdata.cpp
@@ -1,0 +1,99 @@
+/*
+ *  Copyright (c) 2017, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* length of an EUI64 in bytes */
+#define LEN_BIN_EUI64       (64 / 8)
+/* length of EUI64 in ascii form */
+
+#include "steeringdata.hpp"
+#include <stdio.h>
+#include "hex.hpp"
+#include "crc16.hpp"
+#include <string.h>
+
+namespace ot {
+
+bool SteeringData::IsCleared(void)
+{
+    bool rval = true;
+
+    for (uint8_t i = 0; i < GetLength(); i++)
+    {
+        if (mSteeringData[i] != 0)
+        {
+            rval = false;
+            break;
+        }
+    }
+
+    return rval;
+}
+
+void SteeringData::ComputeBloomFilter(const uint8_t *aExtAddress)
+{
+    Crc16 ccitt(Crc16::kCcitt);
+    Crc16 ansi(Crc16::kAnsi);
+
+    for (size_t j = 0; j < (64 / 8); j++)
+    {
+        uint8_t byte = aExtAddress[j];
+        ccitt.Update(byte);
+        ansi.Update(byte);
+    }
+
+    SetBit(ccitt.Get() % GetNumBits());
+    SetBit(ansi.Get() % GetNumBits());
+}
+
+
+
+bool SteeringData::ComputeBloomFilterAscii(const char *ascii_eui64)
+{
+    int     r;
+    uint8_t bin_eui[ LEN_BIN_EUI64 ];
+
+    /* Test 1: simple check for length */
+    if ((LEN_BIN_EUI64 * 2) != strlen(ascii_eui64))
+    {
+        return false;
+    }
+
+    /* convert string as hex bytes */
+    r = ot::Utils::Hex2Bytes(ascii_eui64, bin_eui, sizeof(bin_eui));
+
+    /* how many did we get? */
+    if (r != LEN_BIN_EUI64)
+    {
+        return false;
+    }
+
+    ComputeBloomFilter(bin_eui);
+    return true;
+}
+
+} // namespace

--- a/src/utils/steeringdata.hpp
+++ b/src/utils/steeringdata.hpp
@@ -153,7 +153,7 @@ public:
 
         b = GetLength() - 1 - (aBit / 8);
         m = 1 << (aBit % 8);
-        b = mSteeringData[b] |= m;
+        mSteeringData[b] |= m;
     }
 
     /**

--- a/src/utils/steeringdata.hpp
+++ b/src/utils/steeringdata.hpp
@@ -1,0 +1,201 @@
+/*
+ *  Copyright (c) 2017, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file provides commissioner steering data calculations
+ */
+
+
+#ifndef STEERINGDATA_HPP
+#define STEERINGDATA_HPP
+
+#include <stdint.h> /* c99 types */
+#include <stddef.h> /* size_t */
+#include <string.h> /* memset */
+
+namespace ot {
+
+/**
+ * This class represents Steering Data
+ */
+
+class SteeringData
+{
+public:
+
+    /**
+     * Sets the length of the steering data
+     */
+    void SetLength(int n) { mLength = n; }
+
+    /**
+     * Returns the length of the steering data.
+     */
+    int  GetLength(void) { return mLength; }
+
+    /**
+     * Init the steering data.
+     *
+     */
+    void Init(void) { SetLength(16); Clear(); }
+
+
+    /**
+     * This method sets all bits in the Bloom Filter to zero.
+     *
+     */
+    void Clear(void) { memset(mSteeringData, 0, sizeof(mSteeringData)); }
+
+    /**
+     * Ths method sets all bits in the Bloom Filter to one.
+     *
+     */
+    void Set(void) { memset(mSteeringData, 0xff, sizeof(mSteeringData)); }
+
+    /**
+     * Ths method indicates whether or not the SteeringData allows all Joiners.
+     *
+     * @retval TRUE   If the SteeringData allows all Joiners.
+     * @retval FALSE  If the SteeringData doesn't allow any Joiner.
+     *
+     */
+    bool DoesAllowAny(void) {
+        bool rval = true;
+
+        for (uint8_t i = 0; i < GetLength(); i++)
+        {
+            if (mSteeringData[i] != 0xff)
+            {
+                rval = false;
+                break;
+            }
+        }
+
+        return rval;
+    }
+
+    /**
+     * This method returns the number of bits in the Bloom Filter.
+     *
+     * @returns The number of bits in the Bloom Filter.
+     *
+     */
+    uint8_t GetNumBits(void) { return GetLength() * 8; }
+
+    /**
+     * This method indicates whether or not bit @p aBit is set.
+     *
+     * @param[in]  aBit  The bit offset.
+     *
+     * @retval TRUE   If bit @p aBit is set.
+     * @retval FALSE  If bit @p aBit is not set.
+     *
+     */
+    bool GetBit(uint8_t aBit) {
+        int b;
+        int m;
+
+        b = GetLength() - 1 - (aBit / 8);
+        m = (1 << (aBit % 8));
+        return (mSteeringData[b] & m) != 0;
+    }
+
+    /**
+     * This method clears bit @p aBit.
+     *
+     * @param[in]  aBit  The bit offset.
+     *
+     */
+    void ClearBit(uint8_t aBit) {
+        int b;
+        int m;
+
+        b = GetLength() - 1 - (aBit / 8);
+        m = (1 << (aBit % 8));
+        mSteeringData[b] &= ~(m);
+    }
+
+    /**
+     * This method sets bit @p aBit.
+     *
+     * @param[in]  aBit  The bit offset.
+     *
+     */
+    void SetBit(uint8_t aBit) {
+        int b;
+        int m;
+
+        b = GetLength() - 1 - (aBit / 8);
+        m = 1 << (aBit % 8);
+        b = mSteeringData[b] |= m;
+    }
+
+    /**
+     * Ths method indicates whether or not the SteeringData is all zeros.
+     *
+     * @retval TRUE   If the SteeringData is all zeros.
+     * @retval FALSE  If the SteeringData isn't all zeros.
+     *
+     */
+    bool IsCleared(void);
+
+    /**
+     * This method computes the Bloom Filter.
+     *
+     * @param[in]  pEui64  Extended address
+     *
+     */
+    void ComputeBloomFilter(const uint8_t *pEui64);
+
+    /**
+     * This method uses an ASCII representation of an EUI64
+     * to compute the Bloom filter.
+     *
+     * @param[in] pEui64  Ascii EUI64 text.
+     *
+     * @returns true if ascii EUI64 is valid
+     * @returns false if ascii EUI64 is not well formed.
+     */
+    bool ComputeBloomFilterAscii(const char *pEui64);
+
+    /**
+     * This method returns a pointer to the steering data.
+     * @sa GetByteCount() to determine the length
+     */
+    const uint8_t *GetDataPointer(void) { return &mSteeringData[0]; }
+
+private:
+    /* SPEC states steering ata can be upto 16 bytes long */
+    uint8_t mSteeringData[16];
+    uint8_t mLength;
+};
+
+} /* namespace ot */
+
+#endif

--- a/tests/meshcop/Makefile.am
+++ b/tests/meshcop/Makefile.am
@@ -30,39 +30,44 @@ include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
 noinst_PROGRAMS = otbr-commissioner
 
-otbr_commissioner_SOURCES                                   = \
-    commissioner.cpp                                     \
+otbr_commissioner_SOURCES                             = \
+    commissioner_argcargv.cpp                           \
+    commissioner_compute.cpp                            \
+    commissioner.cpp                                    \
+    commissioner_selftest.cpp                           \
+    commissioner_utils.cpp                              \
     $(NULL)
 
-otbr_commissioner_CPPFLAGS                                  = \
-    -DMBEDTLS_CONFIG_FILE='<config-thread.h>'            \
-    -I$(top_srcdir)/third_party/mbedtls/repo/configs     \
-    -I$(top_srcdir)/third_party/mbedtls/repo/include     \
-    -I$(top_srcdir)/src                                  \
-    -I$(top_srcdir)/src/agent                            \
-    -I$(top_srcdir)/src/web                              \
+otbr_commissioner_CPPFLAGS                            = \
+    -DMBEDTLS_CONFIG_FILE='<config-thread.h>'           \
+    -I$(top_srcdir)/third_party/mbedtls/repo/configs    \
+    -I$(top_srcdir)/third_party/mbedtls/repo/include    \
+    -I$(top_srcdir)/src                                 \
+    -I$(top_srcdir)/src/agent                           \
+    -I$(top_srcdir)/src/web                             \
     $(NULL)
 
-otbr_commissioner_LDADD                                     = \
-    $(top_builddir)/src/agent/libotbr-agent.la           \
-    $(top_builddir)/src/utils/libutils.la                \
-    $(top_builddir)/src/web/libotbr-web.la               \
+otbr_commissioner_LDADD                               = \
+    $(top_builddir)/src/agent/libotbr-agent.la          \
+    $(top_builddir)/src/utils/libutils.la               \
+    $(top_builddir)/src/web/libotbr-web.la              \
+    $(top_builddir)/src/common/libotbr-logging.la       \
     $(NULL)
 
-otbr_commissioner_LDFLAGS                                   = \
-    -static                                              \
+otbr_commissioner_LDFLAGS                             = \
+    -static                                             \
     $(NULL)
 
-EXTRA_DIST                                             = \
-    meshcop                                              \
+EXTRA_DIST                                            = \
+    meshcop                                             \
     $(NULL)
 
-TESTS_ENVIRONMENT                                         = \
-    export                                                  \
-    MAKE=$(MAKE)                                            \
-    top_builddir='$(top_builddir)'                          \
-    top_srcdir='$(top_srcdir)'                              \
-    VERBOSE=1                                               \
+TESTS_ENVIRONMENT                                     = \
+    export                                              \
+    MAKE=$(MAKE)                                        \
+    top_builddir='$(top_builddir)'                      \
+    top_srcdir='$(top_srcdir)'                          \
+    VERBOSE=1                                           \
     LD_LIBRARY_PATH=$(top_builddir)/third_party/cppcms/repo \
     ;
 

--- a/tests/meshcop/Makefile.am
+++ b/tests/meshcop/Makefile.am
@@ -77,4 +77,7 @@ TESTS_ENVIRONMENT                                     = \
 
 TESTS = meshcop
 
+clean-local:
+	rm -f *.log
+
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/tests/meshcop/Makefile.am
+++ b/tests/meshcop/Makefile.am
@@ -30,6 +30,8 @@ include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
 noinst_PROGRAMS = otbr-commissioner
 
+noinst_HEADERS = commissioner.hpp
+
 otbr_commissioner_SOURCES                             = \
     commissioner_argcargv.cpp                           \
     commissioner_compute.cpp                            \
@@ -60,6 +62,8 @@ otbr_commissioner_LDFLAGS                             = \
 
 EXTRA_DIST                                            = \
     meshcop                                             \
+    commissioner.hpp                                    \
+    commissioner_argcargv.hpp                           \
     $(NULL)
 
 TESTS_ENVIRONMENT                                     = \

--- a/tests/meshcop/commissioner.cpp
+++ b/tests/meshcop/commissioner.cpp
@@ -70,7 +70,7 @@ void HandleJoinerFinalize(const Coap::Resource &aResource, const Coap::Message &
     Tlv     *responseTlv = reinterpret_cast<Tlv *>(payload);
 
     otbrLog(OTBR_LOG_INFO, "HandleJoinerFinalize, STATE = 1\n");
-    
+
     context.mState = kStateFinalized;
     responseTlv->SetType(Meshcop::kState);
     responseTlv->SetValue(static_cast<uint8_t>(1));
@@ -876,11 +876,11 @@ static int commissioning_session(Context &context)
         fail("Missing AGENT ip port\n");
     }
 
-    if( aContext.mJoiner.mPSKd_ascii[0] == 0 )
+    if (context.mJoiner.mPSKd_ascii[0] == 0)
     {
-	fail("Missing PSKd (joiner passphrase/password)\n");
+        fail("Missing PSKd (joiner passphrase/password)\n");
     }
-    
+
     context.mSsl = &ssl;
     context.mNet = &client_fd;
     {

--- a/tests/meshcop/commissioner.cpp
+++ b/tests/meshcop/commissioner.cpp
@@ -69,6 +69,8 @@ void HandleJoinerFinalize(const Coap::Resource &aResource, const Coap::Message &
     uint8_t  payload[10];
     Tlv     *responseTlv = reinterpret_cast<Tlv *>(payload);
 
+    otbrLog(OTBR_LOG_INFO, "HandleJoinerFinalize, STATE = 1\n");
+    
     context.mState = kStateFinalized;
     responseTlv->SetType(Meshcop::kState);
     responseTlv->SetValue(static_cast<uint8_t>(1));
@@ -232,6 +234,7 @@ int SendRelayTransmit(Context &aContext)
 
     if (aContext.mState == kStateFinalized)
     {
+        otbrLog(OTBR_LOG_INFO, "realy: KEK state");
         responseTlv->SetType(Meshcop::kJoinerRouterKek);
         responseTlv->SetValue(aContext.mKek, sizeof(aContext.mKek));
         responseTlv = responseTlv->GetNext();
@@ -873,6 +876,11 @@ static int commissioning_session(Context &context)
         fail("Missing AGENT ip port\n");
     }
 
+    if( aContext.mJoiner.mPSKd_ascii[0] == 0 )
+    {
+	fail("Missing PSKd (joiner passphrase/password)\n");
+    }
+    
     context.mSsl = &ssl;
     context.mNet = &client_fd;
     {

--- a/tests/meshcop/commissioner.cpp
+++ b/tests/meshcop/commissioner.cpp
@@ -30,127 +30,19 @@
  * @file
  *   The file implements the Thread commissioner for test.
  */
-
-#include <stdio.h>
-#include <string.h>
-
-#include <arpa/inet.h>
-#include <errno.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <syslog.h>
-
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
-#include <mbedtls/net_sockets.h>
-#include <mbedtls/debug.h>
-#include <mbedtls/ssl.h>
-#include <mbedtls/entropy.h>
-#include <mbedtls/ctr_drbg.h>
-#include <mbedtls/ecjpake.h>
-#include <mbedtls/error.h>
-#include <mbedtls/certs.h>
-#include <mbedtls/timing.h>
-
-#include "agent/coap.hpp"
-#include "agent/dtls.hpp"
-#include "agent/uris.hpp"
-#include "common/tlv.hpp"
-#include "common/code_utils.hpp"
-#include "utils/hex.hpp"
-
-#define SERVER_PORT "49191"
-#define SERVER_NAME "localhost"
-#define SERVER_ADDR "127.0.0.1" /* forces IPv4 */
-
-#define READ_TIMEOUT_MS 1000
-#define MAX_RETRY       5
-
-#define MBEDTLS_DEBUG_C
-#define DEBUG_LEVEL 1
-
-#define SYSLOG_IDENT "otbr-commissioner"
-
-using namespace ot;
-using namespace ot::BorderRouter;
+#include "commissioner.hpp"
 
 const uint8_t kSeed[] = "Commissioner";
-const uint8_t kPSKd[] = "123456";
 const char    kCommissionerId[] = "OpenThread";
 const int     kCipherSuites[] = {
     MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8,
     0
 };
 
-const struct timeval kPollTimeout = {10, 0};
+const struct timeval kPollTimeout = {1, 0};
 
-/**
- * Steering data for joiner 18b4300000000002 with password 123456
- */
-const uint8_t kSteeringData[] = {
-    0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
-};
+struct Context gContext;
 
-/**
- * Constants
- */
-enum
-{
-    kPortJoinerSession = 49192,
-    kSizeMaxPacket     = 1500,
-};
-
-/**
- * Commissioner State
- */
-enum
-{
-    kStateInvalid,
-    kStateConnected,
-    kStateAccepted,
-    kStateReady,
-    kStateAuthenticated,
-    kStateFinalized,
-    kStateDone,
-    kStateError,
-};
-
-/**
- * Commissioner TLV types
- */
-enum
-{
-    kJoinerDtlsEncapsulation
-};
-
-/**
- * Commissioner Context.
- */
-struct Context
-{
-    Coap::Agent         *mCoap;
-    Dtls::Server        *mDtlsServer;
-    Dtls::Session       *mSession;
-
-    mbedtls_ssl_context *mSsl;
-    mbedtls_net_context *mNet;
-
-    int                  mSocket;
-
-    uint16_t             mToken;
-    uint16_t             mCommissionerSessionId;
-    uint8_t              mPSK[16];
-    uint8_t              mKek[32];
-
-    int                  mState;
-
-    uint16_t             mJoinerUdpPort;
-    uint8_t              mJoinerIid[8];
-    uint16_t             mJoinerRouterLocator;
-};
 
 void HandleRelayReceive(const Coap::Resource &aResource, const Coap::Message &aMessage,
                         Coap::Message &aResponse,
@@ -159,6 +51,10 @@ void HandleRelayReceive(const Coap::Resource &aResource, const Coap::Message &aM
 void HandleJoinerFinalize(const Coap::Resource &aResource, const Coap::Message &aMessage,
                           Coap::Message &aResponse,
                           const uint8_t *aIp6, uint16_t aPort, void *aContext);
+
+
+
+
 
 inline uint16_t LengthOf(const void *aStart, const void *aEnd)
 {
@@ -188,11 +84,15 @@ void HandleJoinerFinalize(const Coap::Resource &aResource, const Coap::Message &
     (void)aPort;
 }
 
-void HandleRelayReceive(const Coap::Resource &aResource, const Coap::Message &aMessage,
+void HandleRelayReceive(const Coap::Resource &aResource,
+                        const Coap::Message &aMessage,
                         Coap::Message &aResponse,
-                        const uint8_t *aIp6, uint16_t aPort, void *aContext)
+                        const uint8_t *aIp6,
+                        uint16_t aPort,
+                        void *aContext)
 {
     int            ret = 0;
+    int            tlvtype;
     uint16_t       length;
     Context       &context = *static_cast<Context *>(aContext);
     const uint8_t *payload = aMessage.GetPayload(length);
@@ -201,7 +101,9 @@ void HandleRelayReceive(const Coap::Resource &aResource, const Coap::Message &aM
          LengthOf(payload, requestTlv) < length;
          requestTlv = requestTlv->GetNext())
     {
-        switch (requestTlv->GetType())
+
+        tlvtype = requestTlv->GetType();
+        switch (tlvtype)
         {
         case Meshcop::kJoinerDtlsEncapsulation:
             struct sockaddr_in addr;
@@ -209,24 +111,44 @@ void HandleRelayReceive(const Coap::Resource &aResource, const Coap::Message &aM
             addr.sin_family = AF_INET;
             addr.sin_port = htons(kPortJoinerSession);
 
-            ret = sendto(context.mSocket, requestTlv->GetValue(), requestTlv->GetLength(),
-                         0, reinterpret_cast<const struct sockaddr *>(&addr), sizeof(addr));
+            otbrLog(OTBR_LOG_INFO, "Encapsulation: %d bytes for port: %d",
+                    requestTlv->GetLength(), kPortJoinerSession);
+            {
+                char buf[50];
+                inet_ntop(AF_INET, &addr.sin_addr, buf, sizeof(buf));
+                otbrLog(OTBR_LOG_INFO, "DEST: %s", buf);
+            }
+            ret = sendto(context.mSocket,
+                         requestTlv->GetValue(),
+                         requestTlv->GetLength(),
+                         0,
+                         reinterpret_cast<const struct sockaddr *>(&addr),
+                         sizeof(addr));
+            if (ret < 0)
+            {
+                otbrLog(OTBR_LOG_ERR, "relay receive, sendto() fails with %d", ret);
+            }
             VerifyOrExit(ret != -1, ret = errno);
             break;
 
         case Meshcop::kJoinerUdpPort:
-            context.mJoinerUdpPort = requestTlv->GetValueUInt16();
+            context.mJoiner.mUdpPort = requestTlv->GetValueUInt16();
+            otbrLog(OTBR_LOG_INFO, "JoinerPort: %d", context.mJoiner.mUdpPort);
             break;
 
         case Meshcop::kJoinerIid:
-            memcpy(context.mJoinerIid, requestTlv->GetValue(), sizeof(context.mJoinerIid));
+            memcpy(context.mJoiner.mIid,
+                   requestTlv->GetValue(),
+                   sizeof(context.mJoiner.mIid));
             break;
 
         case Meshcop::kJoinerRouterLocator:
-            context.mJoinerRouterLocator = requestTlv->GetValueUInt16();
+            context.mJoiner.mRouterLocator = requestTlv->GetValueUInt16();
+            otbrLog(OTBR_LOG_INFO, "Router locator: %d", context.mJoiner.mRouterLocator);
             break;
 
         default:
+            otbrLog(OTBR_LOG_INFO, "skip tlv type: %d", tlvtype);
             break;
         }
     }
@@ -241,30 +163,71 @@ exit:
     return;
 }
 
+/* from the example:
+ * http://beej.us/guide/bgnet/output/html/multipage/inet_ntopman.html
+ */
+static char *get_ip_str(const struct sockaddr *sa, char *s, size_t maxlen)
+{
+    switch (sa->sa_family)
+    {
+    case AF_INET:
+        inet_ntop(AF_INET, &(((struct sockaddr_in *)sa)->sin_addr),
+                  s, maxlen);
+        break;
+
+    case AF_INET6:
+        inet_ntop(AF_INET6, &(((struct sockaddr_in6 *)sa)->sin6_addr),
+                  s, maxlen);
+        break;
+
+    default:
+        strncpy(s, "Unknown AF", maxlen);
+        return NULL;
+    }
+
+    return s;
+}
+
 int SendRelayTransmit(Context &aContext)
 {
-    uint8_t payload[kSizeMaxPacket];
-    uint8_t dtlsEncapsulation[kSizeMaxPacket];
-    Tlv    *responseTlv = reinterpret_cast<Tlv *>(payload);
+    uint8_t            payload[kSizeMaxPacket];
+    uint8_t            dtlsEncapsulation[kSizeMaxPacket];
+    Tlv               *responseTlv = reinterpret_cast<Tlv *>(payload);
+    struct sockaddr_in from_addr;
+    socklen_t          addrlen;
 
-    ssize_t ret = recvfrom(aContext.mSocket, dtlsEncapsulation, sizeof(dtlsEncapsulation), 0, NULL, NULL);
+    addrlen = sizeof(from_addr);
+
+
+    ssize_t ret =
+        recvfrom(aContext.mSocket, dtlsEncapsulation, sizeof(dtlsEncapsulation), 0, (struct sockaddr *)(&from_addr),
+                 &addrlen);
 
     VerifyOrExit(ret > 0);
+    {
+        // Print this, because in some environments...
+        // other things on the network use the same port
+        // as open thread is using here :-(
+        char buf[50];
+        get_ip_str((struct sockaddr *)(&from_addr), buf, sizeof(buf));
+        otbrLog(OTBR_LOG_INFO, "relay from: %s\n", buf);
+    }
+
 
     responseTlv->SetType(Meshcop::kJoinerDtlsEncapsulation);
     responseTlv->SetValue(dtlsEncapsulation, static_cast<uint16_t>(ret));
     responseTlv = responseTlv->GetNext();
 
     responseTlv->SetType(Meshcop::kJoinerUdpPort);
-    responseTlv->SetValue(aContext.mJoinerUdpPort);
+    responseTlv->SetValue(aContext.mJoiner.mUdpPort);
     responseTlv = responseTlv->GetNext();
 
     responseTlv->SetType(Meshcop::kJoinerIid);
-    responseTlv->SetValue(aContext.mJoinerIid, sizeof(aContext.mJoinerIid));
+    responseTlv->SetValue(aContext.mJoiner.mIid, sizeof(aContext.mJoiner.mIid));
     responseTlv = responseTlv->GetNext();
 
     responseTlv->SetType(Meshcop::kJoinerRouterLocator);
-    responseTlv->SetValue(aContext.mJoinerRouterLocator);
+    responseTlv->SetValue(aContext.mJoiner.mRouterLocator);
     responseTlv = responseTlv->GetNext();
 
     if (aContext.mState == kStateFinalized)
@@ -276,12 +239,13 @@ int SendRelayTransmit(Context &aContext)
 
     {
         Coap::Message *message;
-        uint16_t       token = ++aContext.mToken;
+        uint16_t       token = ++aContext.mCoapToken;
 
         message = aContext.mCoap->NewMessage(Coap::kTypeNonConfirmable, Coap::kCodePost,
                                              reinterpret_cast<const uint8_t *>(&token), sizeof(token));
         message->SetPath("c/tx");
         message->SetPayload(payload, LengthOf(payload, responseTlv));
+        otbrLog(OTBR_LOG_INFO, "RELAY_tx.req: send");
         aContext.mCoap->Send(*message, NULL, 0, NULL, &aContext);
         aContext.mCoap->FreeMessage(message);
     }
@@ -290,6 +254,7 @@ exit:
     return ret;
 }
 
+/** Sends coap messages via one of the dtls interfaces (agent, or joiner) */
 static ssize_t SendCoap(const uint8_t *aBuffer, uint16_t aLength, const uint8_t *aIp6, uint16_t aPort,
                         void *aContext)
 {
@@ -298,16 +263,19 @@ static ssize_t SendCoap(const uint8_t *aBuffer, uint16_t aLength, const uint8_t 
 
     if (aPort == 0)
     {
+        otbrLog(OTBR_LOG_INFO, "SendCoap: ssl-write-lenth: %d", aLength);
         ret = mbedtls_ssl_write(context.mSsl, aBuffer, aLength);
     }
     else
     {
+        otbrLog(OTBR_LOG_INFO, "SendCoap: session-write-len: %d", aLength);
         if (context.mSession)
         {
             ret = context.mSession->Write(aBuffer, aLength);
         }
         else
         {
+            otbrLog(OTBR_LOG_INFO, "SendCoap: error NO SESSION");
             ret = -1;
         }
     }
@@ -318,18 +286,40 @@ static ssize_t SendCoap(const uint8_t *aBuffer, uint16_t aLength, const uint8_t 
     return ret;
 }
 
+/** callback to print debug from mbed */
 static void my_debug(void *ctx, int level,
                      const char *file, int line,
                      const char *str)
 {
     ((void) level);
-
+    (void)(ctx);
+#if 0
     fprintf((FILE *) ctx, "%s:%04d: %s", file, line, str);
     fflush((FILE *) ctx);
+#endif
+    char buf[100];
+    strncpy(buf, str, sizeof(buf));
+
+    /* mbed inserts EOL and so does otbrLog()
+     * Thus we remove the one from MBED
+     */
+    char *cp;
+    cp = strchr(buf, '\n');
+    if (cp)
+    {
+        *cp = 0;
+    }
+    cp = strchr(buf, '\r');
+    if (cp)
+    {
+        *cp = 0;
+    }
+    otbrLog(OTBR_LOG_INFO, "%s:%d: %s", file, line, buf);
 }
 
-int export_keys(void *aContext, const unsigned char *aMasterSecret, const unsigned char *aKeyBlock,
-                size_t aMacLength, size_t aKeyLength, size_t aIvLength)
+/** dummy function for mbed */
+static int export_keys(void *aContext, const unsigned char *aMasterSecret, const unsigned char *aKeyBlock,
+                       size_t aMacLength, size_t aKeyLength, size_t aIvLength)
 {
     (void)aContext;
     (void)aMasterSecret;
@@ -340,47 +330,61 @@ int export_keys(void *aContext, const unsigned char *aMasterSecret, const unsign
     return 0;
 }
 
-void HandleCommissionerPetition(const Coap::Message &aMessage, void *aContext)
+/** handle c/cp response */
+static void HandleCommissionerPetition(const Coap::Message &aMessage, void *aContext)
 {
     uint16_t       length;
+    int            tlv_type;
     const Tlv     *tlv;
     const uint8_t *payload;
     Context       &context = *static_cast<Context *>(aContext);
 
+    otbrLog(OTBR_LOG_INFO, "COMM_PET.rsp: start");
     payload = aMessage.GetPayload(length);
     tlv = reinterpret_cast<const Tlv *>(payload);
 
     while (LengthOf(payload, tlv) < length)
     {
-        switch (tlv->GetType())
+        tlv_type = tlv->GetType();
+        switch (tlv_type)
         {
         case Meshcop::kState:
             if (tlv->GetValueUInt8())
             {
+                otbrLog(OTBR_LOG_INFO, "COMM_PET.rsp: state=accepted");
                 context.mState = kStateAccepted;
+            }
+            else
+            {
+                otbrLog(OTBR_LOG_INFO, "COMM_PET.rsp: rejected");
             }
             break;
 
         case Meshcop::kCommissionerSessionId:
             context.mCommissionerSessionId = tlv->GetValueUInt16();
+            otbrLog(OTBR_LOG_INFO, "COMM_PET.rsp: session-id=%d", context.mCommissionerSessionId);
             break;
 
         default:
+            otbrLog(OTBR_LOG_INFO, "COMM_PET.rsp: ignore-tilv: %d", tlv_type);
             break;
         }
         tlv = tlv->GetNext();
     }
+    otbrLog(OTBR_LOG_INFO, "COMM_PET.rsp: complete");
 }
 
-int CommissionerPetition(Context &aContext)
+/** Send the c/cp request to the border router agent */
+static int CommissionerPetition(Context &aContext)
 {
     int     ret;
     uint8_t buffer[kSizeMaxPacket];
     Tlv    *tlv = reinterpret_cast<Tlv *>(buffer);
 
     Coap::Message *message;
-    uint16_t       token = ++aContext.mToken;
+    uint16_t       token = ++aContext.mCoapToken;
 
+    otbrLog(OTBR_LOG_INFO, "COMM_PET.req: start");
     token = htons(token);
     message = aContext.mCoap->NewMessage(Coap::kTypeConfirmable, Coap::kCodePost,
                                          reinterpret_cast<const uint8_t *>(&token), sizeof(token));
@@ -390,6 +394,7 @@ int CommissionerPetition(Context &aContext)
 
     message->SetPath("c/cp");
     message->SetPayload(buffer, LengthOf(buffer, tlv));
+    otbrLog(OTBR_LOG_INFO, "COMM_PET.req: send");
     aContext.mCoap->Send(*message, NULL, 0, HandleCommissionerPetition, &aContext);
     aContext.mCoap->FreeMessage(message);
 
@@ -416,64 +421,94 @@ int CommissionerPetition(Context &aContext)
     while (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE);
 
 
+    otbrLog(OTBR_LOG_INFO, "COMM_PET.req: complete");
     return ret;
 }
 
+/** This handles the commissioner data set response, ie: response to the steering data etc */
 void HandleCommissionerSetResponse(const Coap::Message &aMessage, void *aContext)
 {
     uint16_t       length;
+    int            tlv_type;
     const Tlv     *tlv;
     const uint8_t *payload;
     Context       &context = *static_cast<Context *>(aContext);
 
+    otbrLog(OTBR_LOG_INFO, "COMMISSIONER_SET.rsp: start");
     payload = (aMessage.GetPayload(length));
     tlv = reinterpret_cast<const Tlv *>(payload);
 
     while (LengthOf(payload, tlv) < length)
     {
-        switch (tlv->GetType())
+        tlv_type = tlv->GetType();
+        switch (tlv_type)
         {
         case Meshcop::kState:
             if (tlv->GetValueUInt8())
             {
                 context.mState = kStateReady;
+                otbrLog(OTBR_LOG_INFO, "COMMISSIONER_SET.rsp: state=ready");
+            }
+            else
+            {
+                otbrLog(OTBR_LOG_INFO, "COMMISSIONER_SET.rsp: state=NOT-ready");
             }
             break;
 
         case Meshcop::kCommissionerSessionId:
             context.mCommissionerSessionId = tlv->GetValueUInt16();
+            otbrLog(OTBR_LOG_INFO, "COMMISSIONER_SET.rsp: session-id=%d", context.mCommissionerSessionId);
             break;
 
         default:
+            otbrLog(OTBR_LOG_INFO, "COMMISSIONER_SET.rsp: ignore-tlv=%d", tlv_type);
             break;
         }
         tlv = tlv->GetNext();
     }
+    otbrLog(OTBR_LOG_INFO, "COMMISSIONER_SET.rsp: complete");
 }
 
-int CommissionerSet(Context &aContext)
+/** Send the commissioner data (ie: Steering data, etc) to the leader/joining router */
+static int CommissionerSet(Context &aContext)
 {
+    bool     ok;
     int      ret = 0;
-    uint16_t token = ++aContext.mToken;
+    uint16_t token = ++aContext.mCoapToken;
     uint8_t  buffer[kSizeMaxPacket];
     Tlv     *tlv = reinterpret_cast<Tlv *>(buffer);
 
     Coap::Message *message;
 
+    otbrLog(OTBR_LOG_INFO, "COMMISSIONER_SET.req: start");
     token = htons(token);
-    message = aContext.mCoap->NewMessage(Coap::kTypeConfirmable, Coap::kCodePost,
-                                         reinterpret_cast<const uint8_t *>(&token), sizeof(token));
+    message = aContext.mCoap->NewMessage(Coap::kTypeConfirmable,
+                                         Coap::kCodePost,
+                                         reinterpret_cast<const uint8_t *>(&token),
+                                         sizeof(token));
 
     tlv->SetType(Meshcop::kCommissionerSessionId);
     tlv->SetValue(aContext.mCommissionerSessionId);
+    otbrLog(OTBR_LOG_INFO, "COMMISSIONER_SET.req: session-id=%d", aContext.mCommissionerSessionId);
     tlv = tlv->GetNext();
 
+
+    ok = compute_steering();
+    /* Note: Steering computation will have logged the steering data */
+    if (!ok)
+    {
+        fail("Cannot compute steering data\n");
+    }
+
     tlv->SetType(Meshcop::kSteeringData);
-    tlv->SetValue(kSteeringData, sizeof(kSteeringData));
+    tlv->SetValue(aContext.mJoiner.mSteeringData.GetDataPointer(),
+                  aContext.mJoiner.mSteeringData.GetLength());
     tlv = tlv->GetNext();
 
     message->SetPath("c/cs");
+    otbrLog(OTBR_LOG_INFO, "COMMISSIONER_SET.req: coap-uri: %s", "c/cs");
     message->SetPayload(buffer, LengthOf(buffer, tlv));
+    otbrLog(OTBR_LOG_INFO, "COMMISSIONER_SET.req: sent");
     aContext.mCoap->Send(*message, NULL, 0, HandleCommissionerSetResponse, &aContext);
     aContext.mCoap->FreeMessage(message);
 
@@ -503,39 +538,54 @@ int CommissionerSet(Context &aContext)
     return ret;
 }
 
-void HandleCommissionerKeepAlive(const Coap::Message &aMessage, void *aContext)
+/** Handle a COMM_KA response */
+static void HandleCommissionerKeepAlive(const Coap::Message &aMessage, void *aContext)
 {
     uint16_t       length;
+    int            tlv_type;
     const Tlv     *tlv;
     const uint8_t *payload;
     Context       &context = *static_cast<Context *>(aContext);
 
+    otbrLog(OTBR_LOG_INFO, "COMM_KA.rsp: start");
+
+    /* record stats */
+    gettimeofday(&(context.mCOMM_KA.mLastRxTv), NULL);
+    context.mCOMM_KA.mRxCnt += 1;
+
     payload = (aMessage.GetPayload(length));
     tlv = reinterpret_cast<const Tlv *>(payload);
 
+
     while (LengthOf(payload, tlv) < length)
     {
-        switch (tlv->GetType())
+        tlv_type = tlv->GetType();
+        switch (tlv_type)
         {
         case Meshcop::kState:
             if (tlv->GetValueUInt8())
             {
                 context.mState = kStateReady;
+                otbrLog(OTBR_LOG_INFO, "COMM_KA.rsp: state=ready");
             }
             else
             {
+                otbrLog(OTBR_LOG_INFO, "COMM_KA.rsp: state=reject");
                 context.mState = kStateError;
             }
             break;
 
         default:
+            otbrLog(OTBR_LOG_INFO, "COMM_KA.rsp: ignore-tlv=%d", tlv_type);
             break;
         }
         tlv = tlv->GetNext();
     }
+    otbrLog(OTBR_LOG_INFO, "COMM_KA.rsp: complete");
 }
 
-int CommissionerKeepAlive(Context &aContext)
+/** Send a COMM_KA to keep the session alive */
+static int CommissionerKeepAlive(Context &aContext)
 {
     int     ret = 0;
     uint8_t buffer[kSizeMaxPacket];
@@ -543,9 +593,10 @@ int CommissionerKeepAlive(Context &aContext)
 
     Coap::Message *message;
 
-    aContext.mToken++;
+    aContext.mCoapToken++;
     message = aContext.mCoap->NewMessage(Coap::kTypeConfirmable, Coap::kCodePost,
-                                         reinterpret_cast<const uint8_t *>(&aContext.mToken), sizeof(aContext.mToken));
+                                         reinterpret_cast<const uint8_t *>(&aContext.mCoapToken),
+                                         sizeof(aContext.mCoapToken));
 
     tlv->SetType(Meshcop::kState);
     tlv->SetValue(static_cast<uint8_t>(1));
@@ -557,7 +608,12 @@ int CommissionerKeepAlive(Context &aContext)
 
     message->SetPath("c/ca");
     message->SetPayload(buffer, LengthOf(buffer, tlv));
+
+    otbrLog(OTBR_LOG_INFO, "COMM_KA.req: send");
+    gettimeofday(&(aContext.mCOMM_KA.mLastTxTv), NULL);
+    aContext.mCOMM_KA.mTxCnt += 1;
     aContext.mCoap->Send(*message, NULL, 0, HandleCommissionerKeepAlive, &aContext);
+
     aContext.mCoap->FreeMessage(message);
 
     do
@@ -579,10 +635,12 @@ int CommissionerKeepAlive(Context &aContext)
         }
     }
 
+
     return ret;
 }
 
-int CommissionerSessionProcess(Context &context)
+/** This processes IO traffic during the commissioner session */
+static int CommissionerSessionProcess(Context &context)
 {
     uint8_t buf[kSizeMaxPacket];
     int     ret;
@@ -592,18 +650,24 @@ int CommissionerSessionProcess(Context &context)
     {
         context.mCoap->Input(buf, static_cast<uint16_t>(ret), NULL, 0);
     }
+    else
+    {
+        otbrLog(OTBR_LOG_INFO, "CommissionerSessionProcess() ssl error -0x%04x", -ret);
+    }
 
     return ret;
 }
 
-void FeedCoaps(const uint8_t *aBuffer, uint16_t aLength, void *aContext)
+/** send data into the coap session */
+static void FeedCoaps(const uint8_t *aBuffer, uint16_t aLength, void *aContext)
 {
     Context &context = *static_cast<Context *>(aContext);
 
     context.mCoap->Input(aBuffer, aLength, NULL, 1);
 }
 
-void HandleSessionChange(Dtls::Session &aSession, Dtls::Session::State aState, void *aContext)
+/** DTLS session has changed */
+static void HandleSessionChange(Dtls::Session &aSession, Dtls::Session::State aState, void *aContext)
 {
     Context &context = *static_cast<Context *>(aContext);
 
@@ -629,6 +693,56 @@ void HandleSessionChange(Dtls::Session &aSession, Dtls::Session::State aState, v
     }
 }
 
+/** Determine if it is time to send a COMM_KA or not */
+static void CommissionerKeepAliveCheck(Context &aContext)
+{
+    struct timeval tv_now;
+    int            nsecs;
+
+
+    if (aContext.mCOMM_KA.mDisabled)
+    {
+        return;
+    }
+
+    /* check time */
+    gettimeofday(&tv_now, NULL);
+
+
+    nsecs = (int)(tv_now.tv_sec - aContext.mCOMM_KA.mLastTxTv.tv_sec);
+    if (nsecs < aContext.mCOMM_KA.mTxRate)
+    {
+        /* not time yet */
+        return;
+    }
+
+    /* send the COMM_KA */
+    CommissionerKeepAlive(aContext);
+}
+
+/** Do we give up, did we never get a commissioned device? */
+static bool IsEnvelopeTimeout(Context &aContext)
+{
+    struct timeval tv;
+    int            nsecs;
+
+    gettimeofday(&tv, NULL);
+
+    nsecs = (int)(tv.tv_sec - aContext.mEnvelopeStartTv.tv_sec);
+
+    if (nsecs > aContext.mEnvelopeTimeout)
+    {
+        otbrLog(OTBR_LOG_INFO, "ERROR: Envelope Timeout");
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+
+/** Once connected, we await here till a joiner appears... and handle requests */
 int CommissionerServe(Context &aContext)
 {
     fd_set readFdSet;
@@ -636,28 +750,61 @@ int CommissionerServe(Context &aContext)
     fd_set errorFdSet;
     int    ret = 0;
 
+    otbrLog(OTBR_LOG_INFO, "CommissionerServe: start");
     aContext.mSocket = socket(AF_INET, SOCK_DGRAM, 0);
     VerifyOrExit(aContext.mSocket != -1, ret = errno);
     aContext.mDtlsServer = Dtls::Server::Create(kPortJoinerSession, HandleSessionChange, &aContext);
-    aContext.mDtlsServer->SetPSK(kPSKd, strlen(reinterpret_cast<const char *>(kPSKd)));
+
+    otbrLog(OTBR_LOG_INFO, "commissioner-serve: device-pskd=%s", aContext.mJoiner.mPSKd_ascii);
+    aContext.mDtlsServer->SetPSK((const uint8_t *)aContext.mJoiner.mPSKd_ascii, strlen(aContext.mJoiner.mPSKd_ascii));
     aContext.mDtlsServer->Start();
+
+    if (aContext.mCOMM_KA.mDisabled)
+    {
+        /* log this once for 'record keeping' */
+        /* and not in the polling loop */
+        otbrLog(OTBR_LOG_INFO, "COMM_KA: disabled");
+    }
 
     while (aContext.mState != kStateDone && aContext.mState != kStateError)
     {
         struct timeval timeout = kPollTimeout;
         int            maxFd = -1;
 
+
+        otbrLog(OTBR_LOG_DEBUG, "CommissionerServe: Tick..");
+
+
+        /* determine if it is time to send a COMM_KA */
+        if (!aContext.mCOMM_KA.mDisabled)
+        {
+            CommissionerKeepAliveCheck(aContext);
+        }
+
+        if (IsEnvelopeTimeout(aContext))
+        {
+            break;
+        }
+
+        /* Monitor sockets */
         FD_ZERO(&readFdSet);
         FD_ZERO(&writeFdSet);
         FD_ZERO(&errorFdSet);
-
         FD_SET(aContext.mNet->fd, &readFdSet);
+        if (maxFd < aContext.mNet->fd)
+        {
+            maxFd = aContext.mNet->fd;
+        }
         FD_SET(aContext.mSocket, &readFdSet);
+        if (maxFd < aContext.mSocket)
+        {
+            maxFd = aContext.mSocket;
+        }
         aContext.mDtlsServer->UpdateFdSet(readFdSet, writeFdSet, errorFdSet, maxFd, timeout);
         ret = select(maxFd + 1, &readFdSet, &writeFdSet, &errorFdSet, &timeout);
         if ((ret < 0) && (errno != EINTR))
         {
-            perror("select");
+            otbrLog(OTBR_LOG_ERR, "commissioner serve, select errno=%d", errno);
             break;
         }
 
@@ -675,7 +822,13 @@ int CommissionerServe(Context &aContext)
         aContext.mDtlsServer->Process(readFdSet, writeFdSet, errorFdSet);
     }
 
-    aContext.mSession->Close();
+    /* the session with the joiner might not exist.
+     * Example: If we never found the joiner..
+     */
+    if (aContext.mSession)
+    {
+        aContext.mSession->Close();
+    }
     Dtls::Server::Destroy(aContext.mDtlsServer);
     close(aContext.mSocket);
     if (aContext.mState == kStateDone)
@@ -688,13 +841,16 @@ int CommissionerServe(Context &aContext)
     }
 
 exit:
+    otbrLog(OTBR_LOG_INFO, "CommissionerServe: result=%d", ret);
 
     return ret;
 }
 
-int run(Context &context)
+/** this runs a commissioning session end to end */
+static int commissioning_session(Context &context)
 {
     int                          ret;
+    bool                         ok;
     mbedtls_net_context          client_fd;
     mbedtls_entropy_context      entropy;
     mbedtls_ctr_drbg_context     ctr_drbg;
@@ -705,11 +861,25 @@ int run(Context &context)
     Coap::Resource relayReceiveHandler(OT_URI_PATH_RELAY_RX, HandleRelayReceive, &context);
     Coap::Resource joinerFinalizeHandler(OT_URI_PATH_JOINER_FINALIZE, HandleJoinerFinalize, &context);
 
+    otbrLog(OTBR_LOG_INFO, "agent-address: %s", context.mAgent.mAddress_ascii);
+    if (context.mAgent.mAddress_ascii[0] == 0)
+    {
+        fail("Missing AGENT ip address\n");
+    }
+
+    otbrLog(OTBR_LOG_INFO, "agent-port: %s", context.mAgent.mPort_ascii);
+    if (context.mAgent.mPort_ascii[0] == 0)
+    {
+        fail("Missing AGENT ip port\n");
+    }
+
     context.mSsl = &ssl;
     context.mNet = &client_fd;
-#if defined(MBEDTLS_DEBUG_C)
-    mbedtls_debug_set_threshold(DEBUG_LEVEL);
-#endif
+    {
+        int n;
+        n = otbrLogGetLevel();
+        mbedtls_debug_set_threshold(n);
+    }
 
     mbedtls_net_init(&client_fd);
     mbedtls_ssl_init(&ssl);
@@ -721,12 +891,17 @@ int run(Context &context)
                                      kSeed,
                                      sizeof(kSeed))) != 0)
     {
-        goto exit;
+        fail("mbed drgb seed fails?\n");
     }
 
-    if ((ret = mbedtls_net_connect(&client_fd, SERVER_ADDR,
-                                   SERVER_PORT, MBEDTLS_NET_PROTO_UDP)) != 0)
+    otbrLog(OTBR_LOG_INFO, "connecting...");
+    if ((ret = mbedtls_net_connect(&client_fd,
+                                   context.mAgent.mAddress_ascii,
+                                   context.mAgent.mPort_ascii, MBEDTLS_NET_PROTO_UDP)) != 0)
     {
+        fail("CONNECT: %s:%s failed\n",
+             context.mAgent.mAddress_ascii,
+             context.mAgent.mPort_ascii);
         goto exit;
     }
 
@@ -735,6 +910,7 @@ int run(Context &context)
                                            MBEDTLS_SSL_TRANSPORT_DATAGRAM,
                                            MBEDTLS_SSL_PRESET_DEFAULT)) != 0)
     {
+        fail("Cannot configure mbed defaults\n");
         goto exit;
     }
 
@@ -747,19 +923,36 @@ int run(Context &context)
     mbedtls_ssl_conf_export_keys_cb(&conf, export_keys, NULL);
     mbedtls_ssl_conf_handshake_timeout(&conf, 8000, 60000);
 
+    otbrLog(OTBR_LOG_INFO, "connecting: ssl-setup");
     if ((ret = mbedtls_ssl_setup(&ssl, &conf)) != 0)
     {
+        fail("Cannot setup ssl\n");
         goto exit;
     }
 
     mbedtls_ssl_set_bio(&ssl, &client_fd,
-                        mbedtls_net_send, mbedtls_net_recv, mbedtls_net_recv_timeout);
+                        mbedtls_net_send,
+                        mbedtls_net_recv,
+                        mbedtls_net_recv_timeout);
 
-    mbedtls_ssl_set_timer_cb(&ssl, &timer, mbedtls_timing_set_delay,
+    mbedtls_ssl_set_timer_cb(&ssl,
+                             &timer,
+                             mbedtls_timing_set_delay,
                              mbedtls_timing_get_delay);
 
-    mbedtls_ssl_set_hs_ecjpake_password(&ssl, context.mPSK, sizeof(context.mPSK));
 
+    ok = compute_pskc();
+    /* note: compute_pskc will have logged details */
+    if (!ok)
+    {
+        fail("Cannot compute PSKc (commissioning shared key)\n");
+    }
+
+    mbedtls_ssl_set_hs_ecjpake_password(&ssl,
+                                        context.mAgent.mPSKc.bin,
+                                        OT_PSKC_LENGTH);
+
+    otbrLog(OTBR_LOG_INFO, "connect: perform handshake");
     do
     {
         ret = mbedtls_ssl_handshake(&ssl);
@@ -769,19 +962,28 @@ int run(Context &context)
 
     if (ret != 0)
     {
+        otbrLog(OTBR_LOG_ERR, "Handshake fails");
         goto exit;
     }
 
+    otbrLog(OTBR_LOG_INFO, "connect: CONNECTED!");
     context.mState = kStateConnected;
     context.mCoap = Coap::Agent::Create(SendCoap, &context);
 
     SuccessOrExit(ret = context.mCoap->AddResource(relayReceiveHandler));
     SuccessOrExit(ret = context.mCoap->AddResource(joinerFinalizeHandler));
 
+    /** Send the petitioning request */
     SuccessOrExit(ret = CommissionerPetition(context));
+
+    /** Tell network who we want to commission */
     SuccessOrExit(ret = CommissionerSet(context));
+
+    /* and wait for that joiner to appear */
     SuccessOrExit(ret = CommissionerServe(context));
 
+    /* YEA! Success!!!! */
+    otbrLog(OTBR_LOG_INFO, "Closing SSL connection");
     do
     {
         ret = mbedtls_ssl_close_notify(&ssl);
@@ -796,7 +998,7 @@ exit:
     {
         char error_buf[100];
         mbedtls_strerror(ret, error_buf, 100);
-        printf("Last error was: %d - %s\n\n", ret, error_buf);
+        otbrLog(OTBR_LOG_ERR, "mbed error: %d - %s", ret, error_buf);
     }
 #endif
 
@@ -808,31 +1010,54 @@ exit:
     mbedtls_entropy_free(&entropy);
 
     /* Shell can not handle large exit numbers -> 1 for errors */
-    if (ret < 0)
+    if (ret == 0)
     {
-        ret = -1;
+        return EXIT_SUCCESS;
+    }
+    else
+    {
+        return EXIT_FAILURE;
     }
 
     return ret;
 }
 
+
+static void set_context_defaults(void)
+{
+    gContext.mJoiner.mSteeringData.SetLength(kSteeringDefaultLength);
+    gContext.mJoiner.mSteeringData.Clear();
+
+    /* 5minutes is a resonable period of time */
+    gettimeofday(&(gContext.mEnvelopeStartTv), NULL);
+    gContext.mEnvelopeTimeout = 5 * 60;
+
+    /* Set the COMM_KA transmit rate to every 15 seconds */
+    gContext.mCOMM_KA.mTxRate = 15;
+}
+
 int main(int argc, char *argv[])
 {
-    int     ret = 0;
-    Context context;
+    int ret = 0;
 
-    if (argc != 2)
+    /* Set the initial log */
+    otbrLogInit(SYSLOG_IDENT, OTBR_LOG_ERR);
+
+    /* set defaults that may be overridden by the cmdline params */
+    set_context_defaults();
+
+    /* parse command line params */
+    commissioner_argcargv(argc, argv);
+
+    if (!gContext.commission_device)
     {
-        ExitNow(ret = 1);
+        fprintf(stderr, "Nothing todo? Try --help\n");
+        exit(EXIT_FAILURE);
     }
 
-    ot::Utils::Hex2Bytes(argv[1], context.mPSK, sizeof(context.mPSK));
 
-    openlog(SYSLOG_IDENT, LOG_CONS | LOG_PID, LOG_USER);
-
-    ret = run(context);
-
-exit:
-    closelog();
+    /* be a commissioner */
+    ret = commissioning_session(gContext);
+    otbrLog(OTBR_LOG_INFO, "exit: %d\n", ret);
     return ret;
 }

--- a/tests/meshcop/commissioner.hpp
+++ b/tests/meshcop/commissioner.hpp
@@ -88,28 +88,28 @@ using namespace ot::BorderRouter;
 enum
 {
     /* max size of a network packet */
-    kSizeMaxPacket		= 1500,
+    kSizeMaxPacket = 1500,
 
     /* Default size of steering data */
-    kSteeringDefaultLength	= 15,
+    kSteeringDefaultLength = 15,
 
     /* how long is an EUI64 in bytes */
-    kEui64Len			= (64 / 8),
+    kEui64Len = (64 / 8),
 
     /* how long is a PSKd in bytes */
-    kPSKdLength			= 32,
+    kPSKdLength = 32,
 
     /* What port does our internal server use? */
-    kPortJoinerSession		= 49192,
+    kPortJoinerSession = 49192,
 
     /* 64bit xpanid length in bytes */
-    kXpanidLength		= (64/8),    /* 64bits */
+    kXpanidLength = (64 / 8), /* 64bits */
 
     /* specification: 8.10.4 */
-    kNetworkNameLenMax		= 16,
-    
+    kNetworkNameLenMax = 16,
+
     /* Spec is not specific about this items max length, so we choose 64 */
-    kBorderRouterPassPhraseLen	= 64,
+    kBorderRouterPassPhraseLen = 64,
 
 };
 
@@ -139,7 +139,7 @@ enum
     kJoinerDtlsEncapsulation
 };
 
-    
+
 /**
  * Commissioner Context.
  */
@@ -149,135 +149,141 @@ struct Context
     bool commission_device;
 
     /** coap instance to talk to agent & device */
-    Coap::Agent         *mCoap;
+    Coap::Agent *mCoap;
 
     /** dtls info for talking to agent & joiner */
-    Dtls::Server        *mDtlsServer;
+    Dtls::Server *mDtlsServer;
 
     /* the session info for agent & joiner */
-    Dtls::Session       *mSession;
+    Dtls::Session *mSession;
 
     /* dtls context information */
     mbedtls_ssl_context *mSsl;
     mbedtls_net_context *mNet;
 
     /* Socket we are using with the agent */
-    int                  mSocket;
+    int mSocket;
 
     /* this generates our coap tokens */
-    uint16_t             mCoapToken;
+    uint16_t mCoapToken;
 
     /* this is the commissioner session id */
-    uint16_t             mCommissionerSessionId;
+    uint16_t mCommissionerSessionId;
 
     /** all things for the border agent */
-    struct br_agent {
+    struct br_agent
+    {
 
-	/** network port, in form mbed likes it (ascii) */
-	char                 mPort_ascii[ 7 ];
-	
-	/** network address, in form mbed likes it (ascii) */
-	char                 mAddress_ascii[64];
+        /** network port, in form mbed likes it (ascii) */
+        char mPort_ascii[ 7 ];
 
-	/** xpanid from command line & binary form */
-	/* Note: xpanid is used to calculate the PSKc */
-	struct {
-	    char ascii[  (kXpanidLength*2)+1 ];
-	    uint8_t bin  [   kXpanidLength ];
-	} mXpanid;
+        /** network address, in form mbed likes it (ascii) */
+        char mAddress_ascii[64];
 
-	/** network name from command line */
-	/* Note: networkname is used to calculate the PSKc */
-	char mNetworkName[ kNetworkNameLenMax + 1 ];
+        /** xpanid from command line & binary form */
+        /* Note: xpanid is used to calculate the PSKc */
+        struct
+        {
+            char    ascii[  (kXpanidLength * 2) + 1 ];
+            uint8_t bin  [   kXpanidLength ];
+        } mXpanid;
 
-	/** border router agent pass phrase */
-	/* Note: passphrase is used to calculate the PSKc */
-	char mPassPhrase[ kBorderRouterPassPhraseLen + 1 ];
+        /** network name from command line */
+        /* Note: networkname is used to calculate the PSKc */
+        char mNetworkName[ kNetworkNameLenMax + 1 ];
+
+        /** border router agent pass phrase */
+        /* Note: passphrase is used to calculate the PSKc */
+        char mPassPhrase[ kBorderRouterPassPhraseLen + 1 ];
 
 
-	/** the PSKc used with the agent */
-	struct {
+        /** the PSKc used with the agent */
+        struct
+        {
 
-	    /* this class does the calculation */
-	    Psk::Pskc mTool;
+            /* this class does the calculation */
+            Psk::Pskc mTool;
 
-	    /** ascii & binary of PSKc, either from calculation or cmdline */
-	    char ascii[ (OT_PSKC_LENGTH * 2) + 1 ];
-	    uint8_t bin[ OT_PSKC_LENGTH ];
-	} mPSKc;
-	
+            /** ascii & binary of PSKc, either from calculation or cmdline */
+            char    ascii[ (OT_PSKC_LENGTH * 2) + 1 ];
+            uint8_t bin[ OT_PSKC_LENGTH ];
+        } mPSKc;
+
     } mAgent;
 
     /** Kek with the joiner operation */
-    uint8_t              mKek[32];
+    uint8_t mKek[32];
 
-    struct comm_ka {
-	/** last time a COMM_KA message was sent */
-	struct timeval       mLastTxTv;
+    struct comm_ka
+    {
+        /** last time a COMM_KA message was sent */
+        struct timeval mLastTxTv;
 
         /** last time a COMM_KA.rsp was received */
-        struct timeval       mLastRxTv;
+        struct timeval mLastRxTv;
 
         /** how often should these be sent in seconds */
-        int                  mTxRate;
+        int mTxRate;
 
         /** How many have been sent & recieved */
-        int                  mTxCnt;
-        int                  mRxCnt;
+        int mTxCnt;
+        int mRxCnt;
 
         /** are these disabled? (for test purposes) */
-        bool                 mDisabled;
+        bool mDisabled;
     } mCOMM_KA;
 
     /** Total timeout (envelope) of the commissioning test */
     struct               timeval mEnvelopeStartTv;
-    int                  mEnvelopeTimeout;
+    int                          mEnvelopeTimeout;
 
     /** Commissioner state */
-    int                  mState;
-    
+    int mState;
+
 
     /** All things about the joiner */
-    struct joiner {
+    struct joiner
+    {
 
-	/** the EUI64 of the Joiner or HASHMAC, either from cmdline or computed */
-	struct {
-	    char ascii[ (kEui64Len*2) + 1 ];
-	    uint8_t bin[ kEui64Len ];
-	} mEui64, mHashMac;
+        /** the EUI64 of the Joiner or HASHMAC, either from cmdline or computed */
+        struct
+        {
+            char    ascii[ (kEui64Len * 2) + 1 ];
+            uint8_t bin[ kEui64Len ];
+        } mEui64, mHashMac;
 
         /** Set to true/false via cmdline param for test purposes. */
-        bool                 mAllowAny;
+        bool mAllowAny;
 
-	/** Computed steering data based on hashmac */
-	SteeringData         mSteeringData;
+        /** Computed steering data based on hashmac */
+        SteeringData mSteeringData;
 
-	/** UDP port of the joiner */
-	uint16_t             mUdpPort;
+        /** UDP port of the joiner */
+        uint16_t mUdpPort;
 
-	/** Interface id of the joiner device */
-	uint8_t              mIid[8];
+        /** Interface id of the joiner device */
+        uint8_t mIid[8];
 
-	/** the router we are using to talk to the joiner */
-	uint16_t             mRouterLocator;
+        /** the router we are using to talk to the joiner */
+        uint16_t mRouterLocator;
 
-	/** the port we are using */
-	uint16_t             mPortSession;
+        /** the port we are using */
+        uint16_t mPortSession;
 
-	/** This is the PSKd from the command line */
-	/* this is the shared string used by the device */
-	char                 mPSKd_ascii[ kPSKdLength + 1 ];
+        /** This is the PSKd from the command line */
+        /* this is the shared string used by the device */
+        char mPSKd_ascii[ kPSKdLength + 1 ];
 
-	/*
-	 * NOTE: The simplist barcode would contain:
-	 *
-	 *    v=1&&eui=_EUI64_ASCII_&&cc=PSKdASCIITEXT
-	 *
-	 * Example:
-	 *
-	 *    v=1&&eui=00124b000f6e649d&&cc=MYPASSPHRASE
-	 *
-	 */
+        /*
+         * NOTE: The simplist barcode would contain:
+         *
+         *    v=1&&eui=_EUI64_ASCII_&&cc=PSKdASCIITEXT
+         *
+         * Example:
+         *
+         *    v=1&&eui=00124b000f6e649d&&cc=MYPASSPHRASE
+         *
+         */
     } mJoiner;
 };
 
@@ -297,7 +303,7 @@ bool compute_pskc(void);
 const char *hex_string(const uint8_t *pBytes, int n);
 
 /** command line self test handler */
-void handle_selftest( argcargv *pThis );
+void handle_selftest(argcargv *pThis);
 
 /** Print/log an error message and exit */
-void fail(const char *fmt,...);
+void fail(const char *fmt, ...);

--- a/tests/meshcop/commissioner.hpp
+++ b/tests/meshcop/commissioner.hpp
@@ -1,0 +1,303 @@
+/*
+ *    Copyright (c) 2017, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This is a common header for the various commissioner source files.
+ */
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <string.h>
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <syslog.h>
+#include <sys/time.h>
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+#include <mbedtls/net_sockets.h>
+#include <mbedtls/debug.h>
+#include <mbedtls/ssl.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/ecjpake.h>
+#include <mbedtls/error.h>
+#include <mbedtls/certs.h>
+#include <mbedtls/timing.h>
+
+#include "agent/coap.hpp"
+#include "agent/dtls.hpp"
+#include "agent/uris.hpp"
+#include "common/tlv.hpp"
+#include "common/code_utils.hpp"
+#include "common/logging.hpp"
+#include "utils/hex.hpp"
+#include "utils/steeringdata.hpp"
+#include "web/pskc-generator/pskc.hpp"
+
+
+using namespace ot;
+using namespace ot::Utils;
+using namespace ot::BorderRouter;
+
+
+#define MBEDTLS_DEBUG_C
+#define DEBUG_LEVEL 1
+
+#define SYSLOG_IDENT "otbr-commissioner"
+
+#include "commissioner_argcargv.hpp"
+
+/**
+ * Constants
+ */
+enum
+{
+    /* max size of a network packet */
+    kSizeMaxPacket		= 1500,
+
+    /* Default size of steering data */
+    kSteeringDefaultLength	= 15,
+
+    /* how long is an EUI64 in bytes */
+    kEui64Len			= (64 / 8),
+
+    /* how long is a PSKd in bytes */
+    kPSKdLength			= 32,
+
+    /* What port does our internal server use? */
+    kPortJoinerSession		= 49192,
+
+    /* 64bit xpanid length in bytes */
+    kXpanidLength		= (64/8),    /* 64bits */
+
+    /* specification: 8.10.4 */
+    kNetworkNameLenMax		= 16,
+    
+    /* Spec is not specific about this items max length, so we choose 64 */
+    kBorderRouterPassPhraseLen	= 64,
+
+};
+
+
+
+/**
+ * Commissioner State
+ */
+enum
+{
+    kStateInvalid,
+    kStateConnected,
+    kStateAccepted,
+    kStateReady,
+    kStateAuthenticated,
+    kStateFinalized,
+    kStateDone,
+    kStateError,
+};
+
+
+/**
+ * Commissioner TLV types
+ */
+enum
+{
+    kJoinerDtlsEncapsulation
+};
+
+    
+/**
+ * Commissioner Context.
+ */
+struct Context
+{
+    /** Set to true if we should commission the device */
+    bool commission_device;
+
+    /** coap instance to talk to agent & device */
+    Coap::Agent         *mCoap;
+
+    /** dtls info for talking to agent & joiner */
+    Dtls::Server        *mDtlsServer;
+
+    /* the session info for agent & joiner */
+    Dtls::Session       *mSession;
+
+    /* dtls context information */
+    mbedtls_ssl_context *mSsl;
+    mbedtls_net_context *mNet;
+
+    /* Socket we are using with the agent */
+    int                  mSocket;
+
+    /* this generates our coap tokens */
+    uint16_t             mCoapToken;
+
+    /* this is the commissioner session id */
+    uint16_t             mCommissionerSessionId;
+
+    /** all things for the border agent */
+    struct br_agent {
+
+	/** network port, in form mbed likes it (ascii) */
+	char                 mPort_ascii[ 7 ];
+	
+	/** network address, in form mbed likes it (ascii) */
+	char                 mAddress_ascii[64];
+
+	/** xpanid from command line & binary form */
+	/* Note: xpanid is used to calculate the PSKc */
+	struct {
+	    char ascii[  (kXpanidLength*2)+1 ];
+	    uint8_t bin  [   kXpanidLength ];
+	} mXpanid;
+
+	/** network name from command line */
+	/* Note: networkname is used to calculate the PSKc */
+	char mNetworkName[ kNetworkNameLenMax + 1 ];
+
+	/** border router agent pass phrase */
+	/* Note: passphrase is used to calculate the PSKc */
+	char mPassPhrase[ kBorderRouterPassPhraseLen + 1 ];
+
+
+	/** the PSKc used with the agent */
+	struct {
+
+	    /* this class does the calculation */
+	    Psk::Pskc mTool;
+
+	    /** ascii & binary of PSKc, either from calculation or cmdline */
+	    char ascii[ (OT_PSKC_LENGTH * 2) + 1 ];
+	    uint8_t bin[ OT_PSKC_LENGTH ];
+	} mPSKc;
+	
+    } mAgent;
+
+    /** Kek with the joiner operation */
+    uint8_t              mKek[32];
+
+    struct comm_ka {
+	/** last time a COMM_KA message was sent */
+	struct timeval       mLastTxTv;
+
+        /** last time a COMM_KA.rsp was received */
+        struct timeval       mLastRxTv;
+
+        /** how often should these be sent in seconds */
+        int                  mTxRate;
+
+        /** How many have been sent & recieved */
+        int                  mTxCnt;
+        int                  mRxCnt;
+
+        /** are these disabled? (for test purposes) */
+        bool                 mDisabled;
+    } mCOMM_KA;
+
+    /** Total timeout (envelope) of the commissioning test */
+    struct               timeval mEnvelopeStartTv;
+    int                  mEnvelopeTimeout;
+
+    /** Commissioner state */
+    int                  mState;
+    
+
+    /** All things about the joiner */
+    struct joiner {
+
+	/** the EUI64 of the Joiner or HASHMAC, either from cmdline or computed */
+	struct {
+	    char ascii[ (kEui64Len*2) + 1 ];
+	    uint8_t bin[ kEui64Len ];
+	} mEui64, mHashMac;
+
+        /** Set to true/false via cmdline param for test purposes. */
+        bool                 mAllowAny;
+
+	/** Computed steering data based on hashmac */
+	SteeringData         mSteeringData;
+
+	/** UDP port of the joiner */
+	uint16_t             mUdpPort;
+
+	/** Interface id of the joiner device */
+	uint8_t              mIid[8];
+
+	/** the router we are using to talk to the joiner */
+	uint16_t             mRouterLocator;
+
+	/** the port we are using */
+	uint16_t             mPortSession;
+
+	/** This is the PSKd from the command line */
+	/* this is the shared string used by the device */
+	char                 mPSKd_ascii[ kPSKdLength + 1 ];
+
+	/*
+	 * NOTE: The simplist barcode would contain:
+	 *
+	 *    v=1&&eui=_EUI64_ASCII_&&cc=PSKdASCIITEXT
+	 *
+	 * Example:
+	 *
+	 *    v=1&&eui=00124b000f6e649d&&cc=MYPASSPHRASE
+	 *
+	 */
+    } mJoiner;
+};
+
+/* the single global commissioning context */
+extern struct Context gContext;
+
+/* compute the hashmac of a joiner */
+bool compute_hashmac(void);
+
+/** Compute steering data */
+bool compute_steering(void);
+
+/** compute pskc */
+bool compute_pskc(void);
+
+/* return a small string with this data as hex for logging purposes */
+const char *hex_string(const uint8_t *pBytes, int n);
+
+/** command line self test handler */
+void handle_selftest( argcargv *pThis );
+
+/** Print/log an error message and exit */
+void fail(const char *fmt,...);

--- a/tests/meshcop/commissioner.hpp
+++ b/tests/meshcop/commissioner.hpp
@@ -291,19 +291,19 @@ struct Context
 extern struct Context gContext;
 
 /* compute the hashmac of a joiner */
-bool compute_hashmac(void);
+bool CommissionerComputeHashMac(void);
 
 /** Compute steering data */
-bool compute_steering(void);
+bool CommissionerComputeSteering(void);
 
 /** compute pskc */
-bool compute_pskc(void);
+bool CommissionerComputePskc(void);
 
 /* return a small string with this data as hex for logging purposes */
-const char *hex_string(const uint8_t *pBytes, int n);
+const char *CommissionerUtilsHexString(const uint8_t *pBytes, int n);
 
 /** command line self test handler */
-void handle_selftest(argcargv *pThis);
+void CommissionerCmdLineSelfTest(argcargv *pThis);
 
 /** Print/log an error message and exit */
-void fail(const char *fmt, ...);
+void CommissionerUtilsFail(const char *fmt, ...);

--- a/tests/meshcop/commissioner_argcargv.cpp
+++ b/tests/meshcop/commissioner_argcargv.cpp
@@ -477,13 +477,13 @@ static void handle_debug_level(argcargv *pThis)
     int n;
 
     n = pThis->num_param();
-    if( n < OTBR_LOG_EMERG )
+    if (n < OTBR_LOG_EMERG)
     {
         pThis->usage("invalid log level, must be >= %d\n", OTBR_LOG_EMERG);
     }
-    if( n > OTBR_LOG_DEBUG )
+    if (n > OTBR_LOG_DEBUG)
     {
-	n = OTBR_LOG_DEBUG;
+        n = OTBR_LOG_DEBUG;
     }
     otbrLogSetLevel(n);
 }

--- a/tests/meshcop/commissioner_argcargv.cpp
+++ b/tests/meshcop/commissioner_argcargv.cpp
@@ -1,0 +1,610 @@
+/*
+ *    Copyright (c) 2017, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   The file implements the command line params for the commissioner test app.
+ */
+
+#include "commissioner.hpp"
+
+using namespace ot;
+using namespace ot::Utils;
+using namespace ot::BorderRouter;
+
+/** see: commissioner_argcargv.hpp, processes 1 command line parameter */
+int argcargv::parse_args(void)
+{
+    const char                *arg;
+    const struct argcargv_opt *pOPT;
+
+    /* Done? */
+    if (mARGx >= mARGC)
+    {
+        return -1;
+    }
+
+    arg = mARGV[mARGx];
+    /* consume this one */
+    mARGx += 1;
+
+    /* automatically support forms of "-help" */
+    if ((0 == strcmp("-h", arg)) ||
+        (0 == strcmp("-?", arg)) ||
+        (0 == strcmp("-help", arg)) ||
+        (0 == strcmp("--help", arg)))
+    {
+        usage("Help...\n");
+    }
+
+
+    for (pOPT = &mOpts[0]; pOPT->name; pOPT++)
+    {
+        if (0 == strcmp(arg, pOPT->name))
+        {
+            /* found */
+            break;
+        }
+    }
+
+    if (pOPT->name == NULL)
+    {
+        /* not found */
+        usage("Unknown option: %s", arg);
+    }
+
+    (*(pOPT->handler))(this);
+    return 0;
+}
+
+
+/** see: commissioner_argcargv.hpp, fetch an --ARG STRING pair, storing the result */
+const char *argcargv::str_param(char *puthere, size_t bufsiz)
+{
+    const char *cp;
+    size_t      len;
+
+    mARGx += 1; /* skip parameter name */
+    if (mARGx > mARGC)
+    {
+        usage("Missing: %s VALUE\n", mARGV[mARGx - 2]);
+    }
+
+    cp = mARGV[ mARGx - 1];
+
+    /* check length */
+    len = strlen(cp);
+    len++; /* room for null */
+    if (len > bufsiz)
+    {
+        usage("Too long: %s %s\n", mARGV[mARGx - 2], cp);
+    }
+
+    /* save if requested */
+    if (puthere)
+    {
+        strcpy(puthere, cp);
+    }
+    return cp;
+}
+
+
+/** see: commissioner_argcargv.hpp, fetch an --ARG HEXSTRING pair, and decode the hex string storing the result */
+void argcargv::hex_param(char *ascii_puthere, uint8_t *bin_puthere, int bin_len)
+{
+    int n;
+
+    str_param(ascii_puthere, (bin_len * 2) + 1);
+
+    n = Hex2Bytes(ascii_puthere, bin_puthere, bin_len);
+
+    /* hex strings must be *complete* */
+    if (n != bin_len)
+    {
+        usage("Param: %s, invalid hex value %s\n",
+              mARGV[ mARGx - 2 ], mARGV[ mARGx - 1]);
+    }
+}
+
+/** see: commissioner_argcargv.hpp, fetch an --ARG NUMBER pair, returns the numeric value */
+int argcargv::num_param(void)
+{
+    const char *s;
+    char       *ep;
+    int         v;
+
+    /* fetch as string */
+    s = str_param(NULL, 100);
+
+    /* then convert */
+    v = strtol(s, &ep, 0);
+    if ((ep == s) || (*ep != 0))
+    {
+        usage("Not a number: %s %s\n", mARGV[mARGx - 2], mARGV[mARGx - 1]);
+    }
+    return v;
+}
+
+
+/** see: commissioner_argcargv.hpp, constructor for the commissioner argc/argv parser */
+argcargv::argcargv(int argc, char **argv)
+{
+    mARGC = argc;
+    mARGV = argv;
+    mARGx = 1; /* skip the app name */
+
+    memset(&(mOpts[0]), 0, sizeof(mOpts));
+}
+
+
+/** see: commissioner_argcargv.hpp, add an option to be decoded and its handler */
+void argcargv::add_option(const char *name,
+                          void (*handler)(argcargv *pThis),
+                          const char *valuehelp,
+                          const char *helptext)
+{
+    struct argcargv_opt *pOPT;
+    int                  x;
+
+    for (x = 0; x < max_opts; x++)
+    {
+        pOPT = &mOpts[x];
+        if (pOPT->name == NULL)
+        {
+            break;
+        }
+    }
+    if (x >= max_opts)
+    {
+        fail("internal error: Too many cmdline opts!\n");
+    }
+
+    pOPT->name = name;
+    pOPT->handler = handler;
+    pOPT->helptext = helptext;
+    if (valuehelp == NULL)
+    {
+        valuehelp = "";
+    }
+    pOPT->valuehelp = valuehelp;
+}
+
+/** see: commissioner_argcargv.hpp, print error message & application usage */
+void argcargv::usage(const char *fmt, ...)
+{
+    va_list ap;
+
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    va_end(ap);
+
+    fprintf(stderr, "\n");
+    fprintf(stderr, "Usage: %s OPTIONS....\n", mARGV[0]);
+    fprintf(stderr, "\n");
+    fprintf(stderr, "Where OPTIONS are:\n");
+    fprintf(stderr, "\n");
+
+    struct argcargv_opt *pOPT;
+
+    for (pOPT = &mOpts[0]; pOPT->name; pOPT++)
+    {
+        int n;
+
+        n = fprintf(stderr, "    %s %s", pOPT->name, pOPT->valuehelp);
+        fprintf(stderr, "%*s%s\n", (30 - n), "", pOPT->helptext);
+    }
+    fprintf(stderr, "\n");
+    fprintf(stderr, "Note the order of options is important\n");
+    fprintf(stderr, "Example, the option --compute-pskc, has prerequistes of\n");
+    fprintf(stderr, "   --network-name NAME\n");
+    fprintf(stderr, "   --xpanid VALUE\n");
+    fprintf(stderr, "   --agent-passphrase VALUE\n");
+    fprintf(stderr, "\n");
+    exit(EXIT_FAILURE);
+}
+
+
+/** Handle commissioner steering data length command line parameter */
+static void handle_steering_length(argcargv *pThis)
+{
+    int v;
+
+    v = pThis->num_param();
+    if ((v < 1) || (v > 16))
+    {
+        pThis->usage("invalid steering length: %d", v);
+    }
+
+    gContext.mJoiner.mSteeringData.SetLength(v);
+}
+
+/** Handle border router ip address on command line */
+static void handle_ip_addr(argcargv *pThis)
+{
+    pThis->str_param(gContext.mAgent.mAddress_ascii, sizeof(gContext.mAgent.mAddress_ascii));
+}
+
+
+/** Handle border router ip port on command line */
+static void handle_ip_port(argcargv *pThis)
+{
+    pThis->str_param(gContext.mAgent.mPort_ascii, sizeof(gContext.mAgent.mPort_ascii));
+}
+
+/** Handle hex encoded HASHMAC on command line */
+static void handle_hashmac(argcargv *pThis)
+{
+    bool ok;
+
+    pThis->hex_param(gContext.mJoiner.mHashMac.ascii,
+                     gContext.mJoiner.mHashMac.bin,
+                     sizeof(gContext.mJoiner.mHashMac.bin));
+
+    /* once hash mac is know, we can compute the steering data
+     * We assume we have the xpanid & network name.
+     */
+    ok = compute_steering();
+    if (!ok)
+    {
+        pThis->usage("Invalid HASHMAC: %s\n", gContext.mJoiner.mHashMac.ascii);
+    }
+
+}
+
+
+/** Handle joining device EUI64 on the command line */
+static void handle_eui64(argcargv *pThis)
+{
+    bool ok;
+
+    pThis->hex_param(gContext.mJoiner.mEui64.ascii,
+                     gContext.mJoiner.mEui64.bin,
+                     sizeof(gContext.mJoiner.mEui64.bin));
+
+    /* once we have this, we can calculate the HASHMAC
+     * and the steering data.
+     */
+    ok = compute_hashmac();
+    ok = ok && compute_steering();
+    if (!ok)
+    {
+        pThis->usage("Invalid EUI64: %s\n", gContext.mJoiner.mEui64.ascii);
+    }
+}
+
+/** Handle the preshared joining credential for the joining device on the command line */
+static void handle_pskd(argcargv *pThis)
+{
+    const char *whybad;
+    int         ch;
+    int         len, x;
+
+    /* assume not bad */
+    whybad = NULL;
+
+    /* get the parameter */
+    pThis->str_param(gContext.mJoiner.mPSKd_ascii, sizeof(gContext.mJoiner.mPSKd_ascii));
+
+    /*
+     * Problem: Should we "base32" decode this per the specification?
+     * Answer: No - because this needs to be identical to the CLI application
+     * The CLI appication does *NOT* decode preshared key
+     * thus we do not decode the base32 value here
+     * We do however enforce the data..
+     */
+
+    /*
+     * Joining Device Credential
+     * Specification 1.1.1, Section 8.2 Table 8-1
+     * Min Length 6, Max Length 32.
+     *
+     * Digits 0-9, Upper case only Letters A-Z
+     * excluding: I,O,Q,Z
+     *
+     * Note: 26 letters - 4 illegals = 22 letters.
+     * Thus 10 digits + 22 letters = 32 symbols.
+     * Thus, "base32" encoding using the above.
+     */
+    len = strlen(gContext.mJoiner.mPSKd_ascii);
+    if ((len < 6) || (len > 32))
+    {
+        whybad = "invalid length (range: 6..32)";
+    }
+    else
+    {
+
+        for (x = 0; x < len; x++)
+        {
+            ch = gContext.mJoiner.mPSKd_ascii[x];
+
+            switch (ch)
+            {
+            case 'Z':
+            case 'I':
+            case 'O':
+            case 'Q':
+                whybad = "Letters I, O, Q and Z are not allowed";
+                break;
+            default:
+                if (isupper(ch) || isdigit(ch))
+                {
+                    /* all is well */
+                }
+                else
+                {
+                    whybad = "contains non-uppercase or non-digit";
+                }
+                break;
+            }
+            if (whybad)
+            {
+                break;
+            }
+        }
+    }
+
+    if (whybad)
+    {
+        pThis->usage("Illegal PSKd: \"%s\", %s\n",
+                     gContext.mJoiner.mPSKd_ascii, whybad);
+    }
+}
+
+
+/** Handle a pre-computed border agent preshared key, the PSKc
+ * This is derived from the Networkname, Xpanid & passphrase
+ */
+static void handle_pskc_bin(argcargv *pThis)
+{
+    pThis->hex_param(gContext.mAgent.mPSKc.ascii,
+                     gContext.mAgent.mPSKc.bin,
+                     sizeof(gContext.mAgent.mPSKc.bin));
+    otbrLog(OTBR_LOG_INFO, "PSKC on command line is: %s\n", gContext.mAgent.mPSKc.ascii);
+}
+
+
+
+/** handle the xpanid command line parameter */
+static void handle_xpanid(argcargv *pThis)
+{
+    pThis->hex_param(gContext.mAgent.mXpanid.ascii,
+                     gContext.mAgent.mXpanid.bin,
+                     sizeof(gContext.mAgent.mXpanid.bin));
+}
+
+
+/* handle the networkname command line parameter */
+static void handle_netname(argcargv *pThis)
+{
+    pThis->str_param(gContext.mAgent.mNetworkName, sizeof(gContext.mAgent.mNetworkName));
+}
+
+/** handle the border router pass phrase command line parameter */
+static void handle_agent_passphrase(argcargv *pThis)
+{
+    pThis->str_param(gContext.mAgent.mPassPhrase, sizeof(gContext.mAgent.mPassPhrase));
+}
+
+/** Handle log fileanme on the command line */
+static void handle_log_filename(argcargv *pThis)
+{
+    char filename[ PATH_MAX ];
+
+    pThis->str_param(filename, sizeof(filename));
+
+    otbrLogSetFilename(filename);
+}
+
+/** compute the pskc from command line params */
+static void handle_compute_pskc(argcargv *pThis)
+{
+    (void)(pThis);
+    compute_pskc();
+    /* we print this in a way scripts can easily parse */
+    fprintf(stdout, "PSKc: %s\n", gContext.mAgent.mPSKc.ascii);
+    exit(EXIT_SUCCESS);
+}
+
+/** commandline handling for flag that says we commission (not test) */
+static void handle_commission_device(argcargv *pThis)
+{
+    (void)(pThis);
+    gContext.commission_device = true;
+}
+
+
+/** compute hashmac of EUI64 on command line */
+static void handle_compute_hashmac(argcargv *pThis)
+{
+    (void)pThis;
+
+    compute_hashmac();
+    /* print so scripts can easily parse */
+    fprintf(stdout, "eiu64: %s\n", gContext.mJoiner.mEui64.ascii);
+    fprintf(stdout, "hashmac: %s\n", gContext.mJoiner.mHashMac.ascii);
+    exit(EXIT_SUCCESS);
+}
+
+
+/** compute steering based on command line */
+static void handle_compute_steering(argcargv *pThis)
+{
+    (void)pThis;
+
+    compute_steering();
+
+    /* print so scripts can easily parse */
+    fprintf(stdout, "eiu64: %s\n", gContext.mJoiner.mEui64.ascii);
+    fprintf(stdout, "hashmac: %s\n", gContext.mJoiner.mHashMac.ascii);
+    fprintf(stdout, "steering-len: %d\n", gContext.mJoiner.mSteeringData.GetLength());
+    fprintf(stdout, "steering-hex: %s\n",
+            hex_string(
+                gContext.mJoiner.mSteeringData.GetDataPointer(),
+                gContext.mJoiner.mSteeringData.GetLength()));
+
+    exit(EXIT_SUCCESS);
+}
+
+
+/** handle debug level on command line */
+static void handle_debug_level(argcargv *pThis)
+{
+    int n;
+
+    n = pThis->num_param();
+    if (n < OTBR_LOG_EMERG)
+    {
+        n = OTBR_LOG_EMERG;
+    }
+    if (n > OTBR_LOG_DEBUG)
+    {
+        n = OTBR_LOG_DEBUG;
+    }
+}
+
+/** handle steering allow any on command line */
+static void handle_allow_all_joiners(argcargv *pThis)
+{
+    (void)(pThis);
+    bool ok;
+
+    gContext.mJoiner.mAllowAny = true;
+    /* once we have this, we can calculate the HASHMAC
+     * and the steering data.
+     */
+    ok = compute_steering();
+    if (!ok)
+    {
+        fail("Cannot compute steering\n");
+    }
+}
+
+/** user wants to disable COMM_KA transmissions for test purposes */
+static void handle_comm_ka_disabled(argcargv *pThis)
+{
+    (void)(pThis);
+    gContext.mCOMM_KA.mDisabled = true;
+}
+
+/** user wants to adjust COMM_KA transmission rate */
+static void handle_comm_ka_rate(argcargv *pThis)
+{
+    int n;
+
+    n = pThis->num_param();
+    /* sanity... */
+
+    /* note: 86400 = 1 day in seconds */
+    if ((n < 3) || (n > 86400))
+    {
+        pThis->usage("comm-ka rate must be (n>3) && (n < 86400), not: %d\n", n);
+    }
+    gContext.mCOMM_KA.mTxRate = n;
+}
+
+/** Adjust total envelope timeout for test automation reasons */
+static void handle_comm_envelope_timeout(argcargv *pThis)
+{
+    int n;
+
+    /*
+     * This exists because if the COMM_KA keeps going
+     * nothing will stop... and test scripts run forever!
+     */
+
+    n = pThis->num_param();
+    /* between 1 second and 1 day.. */
+    if ((n < 1) || (n > (86400)))
+    {
+        pThis->usage("Invalid envelope time, range: 1 <= n <= 86400, not %d\n", n);
+    }
+    gContext.mEnvelopeTimeout = n;
+}
+
+/* handle disabling syslog on command line */
+static void handle_no_syslog(argcargv *pThis)
+{
+    (void)(pThis);
+    otbrLogEnableSyslog(false);
+}
+
+
+/** Called by main(), to process commissioner command line arguments */
+void commissioner_argcargv(int argc, char **argv)
+{
+    argcargv args(argc, argv);
+
+    args.add_option("--selftest",                handle_selftest,                "",
+                    "perform internal selftests");
+    args.add_option("--joiner-eui64",            handle_eui64,                   "VALUE",       "joiner EUI64 value");
+    args.add_option("--hashmac",                handle_hashmac,                 "VALUE",       "joiner HASHMAC value");
+    args.add_option("--agent-passphrase",        handle_agent_passphrase,        "VALUE",
+                    "Pass phrase for agent");
+    args.add_option("--network-name",            handle_netname,                 "VALUE",
+                    "UTF8 encoded network name");
+    args.add_option("--xpanid",                  handle_xpanid,                  "VALUE",       "xpanid in hex");
+    args.add_option("--pskc-bin",                handle_pskc_bin,                "VALUE",
+                    "Precomputed PSKc in hex notation");
+    args.add_option("--joiner-passphrase",       handle_pskd,                    "VALUE",       "PSKd for joiner");
+    args.add_option("--steering-length",         handle_steering_length,         "NUMBER",
+                    "Length of steering data 1..15");
+    args.add_option("--allow-all-joiners",       handle_allow_all_joiners,       "",
+                    "Allow any device to join");
+    args.add_option("--agent-addr",              handle_ip_addr,                 "VALUE",
+                    "ip address of border router agent");
+    args.add_option("--agent-port",              handle_ip_port,                 "VALUE",
+                    "ip port used by border router agent");
+    args.add_option("--log-filename",            handle_log_filename,            "FILENAME",    "set logfilename");
+    args.add_option("--compute-pskc",            handle_compute_pskc,            "",
+                    "compute and print the pskc from parameters");
+    args.add_option("--compute-hashmac",         handle_compute_hashmac,         "",
+                    "compute and print the hashmac of the given eui64");
+    args.add_option("--compute-steering",        handle_compute_steering,        "",
+                    "compute and print steering data");
+    args.add_option("--comm-ka-disabled",        handle_comm_ka_disabled,        "",
+                    "Disable COMM_KA transmissions");
+    args.add_option("--comm-ka-rate",            handle_comm_ka_rate,            "",
+                    "Set COMM_KA transmission rate");
+    args.add_option("--disable-syslog",          handle_no_syslog,               "",
+                    "Disable log via syslog");
+    args.add_option("--comm-envelope-timeout",   handle_comm_envelope_timeout,   "VALUE",
+                    "Set the total envelope timeout for commissioning");
+
+    args.add_option("--commission-device",       handle_commission_device,       "",
+                    "Enable device commissioning");
+
+    args.add_option("--debug-level",             handle_debug_level,             "NUMBER",
+                    "Enable debug output at level VALUE (higher=more)");
+    if (argc == 1)
+    {
+        args.usage("No parameters!\n");
+    }
+    /* parse the args */
+    while (args.parse_args() != -1)
+        ;
+}

--- a/tests/meshcop/commissioner_argcargv.cpp
+++ b/tests/meshcop/commissioner_argcargv.cpp
@@ -484,7 +484,7 @@ static void handle_debug_level(argcargv *pThis)
     }
     else
     {
-	otbrLogSetlevel(n);
+	otbrLogSetLevel(n);
     }
 }
 

--- a/tests/meshcop/commissioner_argcargv.cpp
+++ b/tests/meshcop/commissioner_argcargv.cpp
@@ -477,14 +477,14 @@ static void handle_debug_level(argcargv *pThis)
     int n;
 
     n = pThis->num_param();
-    if( !((n >= OTBR_LOG_EMERG) && (n <= OTBR_LOG_DEBUG) ) )
+    if (!((n >= OTBR_LOG_EMERG) && (n <= OTBR_LOG_DEBUG)))
     {
-	pThis->usage("invalid log level, range: %d to %d, not: %d\n",
-		     OTBR_LOG_EMERG, OTBR_LOG_DEBUG, n );
+        pThis->usage("invalid log level, range: %d to %d, not: %d\n",
+                     OTBR_LOG_EMERG, OTBR_LOG_DEBUG, n);
     }
     else
     {
-	otbrLogSetLevel(n);
+        otbrLogSetLevel(n);
     }
 }
 

--- a/tests/meshcop/commissioner_argcargv.cpp
+++ b/tests/meshcop/commissioner_argcargv.cpp
@@ -477,13 +477,14 @@ static void handle_debug_level(argcargv *pThis)
     int n;
 
     n = pThis->num_param();
-    if (n < OTBR_LOG_EMERG)
+    if( !((n >= OTBR_LOG_EMERG) && (n <= OTBR_LOG_DEBUG) ) )
     {
-        n = OTBR_LOG_EMERG;
+	pThis->usage("invalid log level, range: %d to %d, not: %d\n",
+		     OTBR_LOG_EMERG, OTBR_LOG_DEBUG, n );
     }
-    if (n > OTBR_LOG_DEBUG)
+    else
     {
-        n = OTBR_LOG_DEBUG;
+	otbrLogSetlevel(n);
     }
 }
 

--- a/tests/meshcop/commissioner_argcargv.cpp
+++ b/tests/meshcop/commissioner_argcargv.cpp
@@ -181,7 +181,7 @@ void argcargv::add_option(const char *name,
     }
     if (x >= max_opts)
     {
-        fail("internal error: Too many cmdline opts!\n");
+        CommissionerUtilsFail("internal error: Too many cmdline opts!\n");
     }
 
     pOPT->name = name;
@@ -268,7 +268,7 @@ static void handle_hashmac(argcargv *pThis)
     /* once hash mac is know, we can compute the steering data
      * We assume we have the xpanid & network name.
      */
-    ok = compute_steering();
+    ok = CommissionerComputeSteering();
     if (!ok)
     {
         pThis->usage("Invalid HASHMAC: %s\n", gContext.mJoiner.mHashMac.ascii);
@@ -289,8 +289,8 @@ static void handle_eui64(argcargv *pThis)
     /* once we have this, we can calculate the HASHMAC
      * and the steering data.
      */
-    ok = compute_hashmac();
-    ok = ok && compute_steering();
+    ok = CommissionerComputeHashMac();
+    ok = ok && CommissionerComputeSteering();
     if (!ok)
     {
         pThis->usage("Invalid EUI64: %s\n", gContext.mJoiner.mEui64.ascii);
@@ -424,7 +424,7 @@ static void handle_log_filename(argcargv *pThis)
 static void handle_compute_pskc(argcargv *pThis)
 {
     (void)(pThis);
-    compute_pskc();
+    CommissionerComputePskc();
     /* we print this in a way scripts can easily parse */
     fprintf(stdout, "PSKc: %s\n", gContext.mAgent.mPSKc.ascii);
     exit(EXIT_SUCCESS);
@@ -443,7 +443,7 @@ static void handle_compute_hashmac(argcargv *pThis)
 {
     (void)pThis;
 
-    compute_hashmac();
+    CommissionerComputeHashMac();
     /* print so scripts can easily parse */
     fprintf(stdout, "eiu64: %s\n", gContext.mJoiner.mEui64.ascii);
     fprintf(stdout, "hashmac: %s\n", gContext.mJoiner.mHashMac.ascii);
@@ -456,14 +456,14 @@ static void handle_compute_steering(argcargv *pThis)
 {
     (void)pThis;
 
-    compute_steering();
+    CommissionerComputeSteering();
 
     /* print so scripts can easily parse */
     fprintf(stdout, "eiu64: %s\n", gContext.mJoiner.mEui64.ascii);
     fprintf(stdout, "hashmac: %s\n", gContext.mJoiner.mHashMac.ascii);
     fprintf(stdout, "steering-len: %d\n", gContext.mJoiner.mSteeringData.GetLength());
     fprintf(stdout, "steering-hex: %s\n",
-            hex_string(
+            CommissionerUtilsHexString(
                 gContext.mJoiner.mSteeringData.GetDataPointer(),
                 gContext.mJoiner.mSteeringData.GetLength()));
 
@@ -498,10 +498,10 @@ static void handle_allow_all_joiners(argcargv *pThis)
     /* once we have this, we can calculate the HASHMAC
      * and the steering data.
      */
-    ok = compute_steering();
+    ok = CommissionerComputeSteering();
     if (!ok)
     {
-        fail("Cannot compute steering\n");
+        CommissionerUtilsFail("Cannot compute steering\n");
     }
 }
 
@@ -560,10 +560,10 @@ void commissioner_argcargv(int argc, char **argv)
 {
     argcargv args(argc, argv);
 
-    args.add_option("--selftest",                handle_selftest,                "",
+    args.add_option("--selftest",                CommissionerCmdLineSelfTest,    "",
                     "perform internal selftests");
     args.add_option("--joiner-eui64",            handle_eui64,                   "VALUE",       "joiner EUI64 value");
-    args.add_option("--hashmac",                handle_hashmac,                 "VALUE",       "joiner HASHMAC value");
+    args.add_option("--hashmac",                 handle_hashmac,                 "VALUE",       "joiner HASHMAC value");
     args.add_option("--agent-passphrase",        handle_agent_passphrase,        "VALUE",
                     "Pass phrase for agent");
     args.add_option("--network-name",            handle_netname,                 "VALUE",

--- a/tests/meshcop/commissioner_argcargv.cpp
+++ b/tests/meshcop/commissioner_argcargv.cpp
@@ -41,7 +41,7 @@ using namespace ot::BorderRouter;
 int argcargv::parse_args(void)
 {
     const char                *arg;
-    const struct argcargv_opt *pOPT;
+    const struct argcargv_opt *opt;
 
     /* Done? */
     if (mARGx >= mARGC)
@@ -63,22 +63,22 @@ int argcargv::parse_args(void)
     }
 
 
-    for (pOPT = &mOpts[0]; pOPT->name; pOPT++)
+    for (opt = &mOpts[0]; opt->name; opt++)
     {
-        if (0 == strcmp(arg, pOPT->name))
+        if (0 == strcmp(arg, opt->name))
         {
             /* found */
             break;
         }
     }
 
-    if (pOPT->name == NULL)
+    if (opt->name == NULL)
     {
         /* not found */
         usage("Unknown option: %s", arg);
     }
 
-    (*(pOPT->handler))(this);
+    (*(opt->handler))(this);
     return 0;
 }
 
@@ -168,13 +168,13 @@ void argcargv::add_option(const char *name,
                           const char *valuehelp,
                           const char *helptext)
 {
-    struct argcargv_opt *pOPT;
+    struct argcargv_opt *opt;
     int                  x;
 
     for (x = 0; x < max_opts; x++)
     {
-        pOPT = &mOpts[x];
-        if (pOPT->name == NULL)
+        opt = &mOpts[x];
+        if (opt->name == NULL)
         {
             break;
         }
@@ -184,14 +184,14 @@ void argcargv::add_option(const char *name,
         CommissionerUtilsFail("internal error: Too many cmdline opts!\n");
     }
 
-    pOPT->name = name;
-    pOPT->handler = handler;
-    pOPT->helptext = helptext;
+    opt->name = name;
+    opt->handler = handler;
+    opt->helptext = helptext;
     if (valuehelp == NULL)
     {
         valuehelp = "";
     }
-    pOPT->valuehelp = valuehelp;
+    opt->valuehelp = valuehelp;
 }
 
 /** see: commissioner_argcargv.hpp, print error message & application usage */
@@ -209,14 +209,14 @@ void argcargv::usage(const char *fmt, ...)
     fprintf(stderr, "Where OPTIONS are:\n");
     fprintf(stderr, "\n");
 
-    struct argcargv_opt *pOPT;
+    struct argcargv_opt *opt;
 
-    for (pOPT = &mOpts[0]; pOPT->name; pOPT++)
+    for (opt = &mOpts[0]; opt->name; opt++)
     {
         int n;
 
-        n = fprintf(stderr, "    %s %s", pOPT->name, pOPT->valuehelp);
-        fprintf(stderr, "%*s%s\n", (30 - n), "", pOPT->helptext);
+        n = fprintf(stderr, "    %s %s", opt->name, opt->valuehelp);
+        fprintf(stderr, "%*s%s\n", (30 - n), "", opt->helptext);
     }
     fprintf(stderr, "\n");
     fprintf(stderr, "Note the order of options is important\n");

--- a/tests/meshcop/commissioner_argcargv.cpp
+++ b/tests/meshcop/commissioner_argcargv.cpp
@@ -477,15 +477,15 @@ static void handle_debug_level(argcargv *pThis)
     int n;
 
     n = pThis->num_param();
-    if (!((n >= OTBR_LOG_EMERG) && (n <= OTBR_LOG_DEBUG)))
+    if( n < OTBR_LOG_EMERG )
     {
-        pThis->usage("invalid log level, range: %d to %d, not: %d\n",
-                     OTBR_LOG_EMERG, OTBR_LOG_DEBUG, n);
+        pThis->usage("invalid log level, must be >= %d\n", OTBR_LOG_EMERG);
     }
-    else
+    if( n > OTBR_LOG_DEBUG )
     {
-        otbrLogSetLevel(n);
+	n = OTBR_LOG_DEBUG;
     }
+    otbrLogSetLevel(n);
 }
 
 /** handle steering allow any on command line */

--- a/tests/meshcop/commissioner_argcargv.hpp
+++ b/tests/meshcop/commissioner_argcargv.hpp
@@ -1,0 +1,125 @@
+/*
+ *    Copyright (c) 2017, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   The file is the header for the command line params for the commissioner test app.
+ */
+
+#if !defined(COMMISSIONER_HPP_H)
+#define COMMISSIONER_HPP_H
+
+/**
+ * Simple class to handle command line parameters
+ * To avoid the use of "getopt_long()" we have this.
+ */
+
+/* forward */
+class argcargv;
+
+/* option entry in our table */
+struct argcargv_opt {
+    const char *name;
+    void (*handler)(argcargv *);
+    const char *valuehelp;
+    const char *helptext;
+};
+
+class argcargv {
+public:
+
+    /** Constructor */
+    argcargv( int argc, char **argv );
+
+    /** pseudo globals for argc & argv parsing */
+    int mARGC;     /* analogous to argc */
+    char **mARGV;  /* analogous to argv */
+    int mARGx;     /**< current argument */
+
+    enum {
+	max_opts = 40
+    };
+    struct argcargv_opt mOpts[max_opts];
+
+    /** print usage error message and exit */
+    void usage( const char *fmt,...);
+
+    /** add an option to be parsed */
+    void add_option( const char *name,
+		     void (*handler)( argcargv *pThis ),
+		     const char *valuehelp,
+		     const char *help );
+    
+    /** 
+     * fetch/parse a string parameter
+     * 
+     * @param puthere[out] holds parameter string
+     * @param maxlen[in]   size of the puthere buffer, including space for null
+     */
+    const char *str_param(char *puthere, size_t maxlen);
+
+    /**
+     * Parse a hex encoded string from the command line.
+     * @param ascii_puthere[out]  the ascii encoded data will be placed here
+     * @param bin_puthere[out]    the resulting/decoded binary data will be here.
+     * @param sizeof_bin[in]      the size of the binary buffer
+     *
+     * The sizeof_bin also specifies the required size of the hex
+     * encoded data on the command line, for example if size_bin==4
+     *
+     * Then there must be exactly 8 hex digits in the command line parameter
+     */
+    void        hex_param(char *ascii_puthere, uint8_t *bin_puthere, int sizeof_bin );
+
+    /**
+     * Parse a numeric parameter from the command line
+     *
+     * If something is wrong print an error & usage text.
+     *
+     * @returns value from command line as an integer
+     */
+    int         num_param(void);
+
+
+    /** 
+     *  This parses a single command line parameter
+     *
+     * @returns 0 if there are more parameters to parse
+     * @returns -1 if there are no more parameters to parse
+     *
+     * This does not handle positional parameters.
+     */
+    int         parse_args(void);
+};
+
+/**
+ * Called from main() to parse the commissioner test app command line parameters.
+ */
+void commissioner_argcargv( int argc, char **argv );
+
+#endif

--- a/tests/meshcop/commissioner_compute.cpp
+++ b/tests/meshcop/commissioner_compute.cpp
@@ -35,7 +35,7 @@
 
 
 /** the hashmac is used in the steering data */
-bool compute_hashmac(void)
+bool CommissionerComputeHashMac(void)
 {
     /* given ascii eui64, compute hashmac */
     mbedtls_sha256_context sha256;
@@ -55,7 +55,7 @@ bool compute_hashmac(void)
 
         if (gContext.mJoiner.mEui64.ascii[0] == 0)
         {
-            fail("MISSING EUI64 address\n");
+            CommissionerUtilsFail("MISSING EUI64 address\n");
             return false;
         }
 
@@ -64,7 +64,7 @@ bool compute_hashmac(void)
                        sizeof(gContext.mJoiner.mEui64.bin));
         if (r != 8)
         {
-            fail("eui64 wrong length, or non-hex data\n");
+            CommissionerUtilsFail("eui64 wrong length, or non-hex data\n");
             return false;
         }
         mbedtls_sha256_init(&sha256);
@@ -92,7 +92,7 @@ bool compute_hashmac(void)
 
 
 /** compute preshared key for commissioner */
-bool compute_pskc(void)
+bool CommissionerComputePskc(void)
 {
 
     const uint8_t *pKey;
@@ -108,21 +108,21 @@ bool compute_pskc(void)
         otbrLog(OTBR_LOG_INFO, "xpanid: %s", gContext.mAgent.mXpanid.ascii);
         if (gContext.mAgent.mXpanid.ascii[0] == 0)
         {
-            fail("compute PSKc: Missing xpanid\n");
+            CommissionerUtilsFail("compute PSKc: Missing xpanid\n");
             return false;
         }
 
         otbrLog(OTBR_LOG_INFO, "networkname: %s", gContext.mAgent.mNetworkName);
         if (gContext.mAgent.mNetworkName[0] == 0)
         {
-            fail("compute PSKc: Missing networkname\n");
+            CommissionerUtilsFail("compute PSKc: Missing networkname\n");
             return false;
         }
 
         otbrLog(OTBR_LOG_INFO, "passphrase: %s", gContext.mAgent.mPassPhrase);
         if (gContext.mAgent.mPassPhrase[0] == 0)
         {
-            fail("compute PSKc: Missing br passphrase\n");
+            CommissionerUtilsFail("compute PSKc: Missing br passphrase\n");
             return false;
         }
 
@@ -141,7 +141,7 @@ bool compute_pskc(void)
 }
 
 /** compute the steering data */
-bool compute_steering(void)
+bool CommissionerComputeSteering(void)
 {
     bool ok;
 
@@ -156,7 +156,7 @@ bool compute_steering(void)
         }
 
         /* We require a hashmac */
-        ok = compute_hashmac();
+        ok = CommissionerComputeHashMac();
         if (!ok)
         {
             otbrLog(OTBR_LOG_INFO, "error: Cannot calculate steering data, bad hashmac");
@@ -181,7 +181,7 @@ bool compute_steering(void)
         pBytes = gContext.mJoiner.mSteeringData.GetDataPointer();
 
         otbrLog(OTBR_LOG_INFO, "steering-len: %d", n);
-        otbrLog(OTBR_LOG_INFO, "steering-hex: %s", hex_string(pBytes, n));
+        otbrLog(OTBR_LOG_INFO, "steering-hex: %s", CommissionerUtilsHexString(pBytes, n));
     }
     return ok;
 }

--- a/tests/meshcop/commissioner_compute.cpp
+++ b/tests/meshcop/commissioner_compute.cpp
@@ -1,0 +1,187 @@
+/*
+ *    Copyright (c) 2017, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   The file computes various values used during commissioning.
+ */
+
+#include "commissioner.hpp"
+
+
+/** the hashmac is used in the steering data */
+bool compute_hashmac(void)
+{
+    /* given ascii eui64, compute hashmac */
+    mbedtls_sha256_context sha256;
+    uint8_t                hash_result[32];
+    int                    r;
+
+    /* convert ascii EUI64 into BIN EUI64 */
+    otbrLog(OTBR_LOG_INFO, "eui64: %s", gContext.mJoiner.mEui64.ascii);
+
+    /* do we need to do this? */
+    if (gContext.mJoiner.mHashMac.ascii[0])
+    {
+        otbrLog(OTBR_LOG_INFO, "note: hashmac already computed or provided");
+    }
+    else
+    {
+
+        if (gContext.mJoiner.mEui64.ascii[0] == 0)
+        {
+            fail("MISSING EUI64 address\n");
+            return false;
+        }
+
+        r =  Hex2Bytes(gContext.mJoiner.mEui64.ascii,
+                       gContext.mJoiner.mEui64.bin,
+                       sizeof(gContext.mJoiner.mEui64.bin));
+        if (r != 8)
+        {
+            fail("eui64 wrong length, or non-hex data\n");
+            return false;
+        }
+        mbedtls_sha256_init(&sha256);
+        mbedtls_sha256_starts(&sha256, 0);
+        mbedtls_sha256_update(&sha256,
+                              gContext.mJoiner.mEui64.bin,
+                              sizeof(gContext.mJoiner.mEui64.bin));
+
+        mbedtls_sha256_finish(&sha256, hash_result);
+        /* Bytes 0..7, is the new data */
+        memcpy(gContext.mJoiner.mHashMac.bin, hash_result, 8);
+        /* Set the locally admin bit, byte 0, bit 1 */
+        gContext.mJoiner.mHashMac.bin[0] |= 2;
+        /* we now have the HASHMAC value */
+        /* convert to ascii */
+        Bytes2Hex(gContext.mJoiner.mHashMac.bin,
+                  8,
+                  gContext.mJoiner.mHashMac.ascii);
+    }
+    otbrLog(OTBR_LOG_INFO, "hash-mac: %s", gContext.mJoiner.mHashMac.ascii);
+
+    /* success */
+    return true;
+}
+
+
+/** compute preshared key for commissioner */
+bool compute_pskc(void)
+{
+
+    const uint8_t *pKey;
+
+    /* do we need to do this? */
+    if (gContext.mAgent.mPSKc.ascii[0])
+    {
+        otbrLog(OTBR_LOG_INFO, "note: PSKc already computed, or provided");
+    }
+    else
+    {
+
+        otbrLog(OTBR_LOG_INFO, "xpanid: %s", gContext.mAgent.mXpanid.ascii);
+        if (gContext.mAgent.mXpanid.ascii[0] == 0)
+        {
+            fail("compute PSKc: Missing xpanid\n");
+            return false;
+        }
+
+        otbrLog(OTBR_LOG_INFO, "networkname: %s", gContext.mAgent.mNetworkName);
+        if (gContext.mAgent.mNetworkName[0] == 0)
+        {
+            fail("compute PSKc: Missing networkname\n");
+            return false;
+        }
+
+        otbrLog(OTBR_LOG_INFO, "passphrase: %s", gContext.mAgent.mPassPhrase);
+        if (gContext.mAgent.mPassPhrase[0] == 0)
+        {
+            fail("compute PSKc: Missing br passphrase\n");
+            return false;
+        }
+
+        otbrLog(OTBR_LOG_INFO, "note: calculating PSKc");
+        pKey = gContext.mAgent.mPSKc.mTool.ComputePskc(gContext.mAgent.mXpanid.bin,
+                                                       gContext.mAgent.mNetworkName,
+                                                       gContext.mAgent.mPassPhrase);
+
+        memcpy(gContext.mAgent.mPSKc.bin, pKey, OT_PSKC_LENGTH);
+        /* convert to ascii for log purposes */
+        Bytes2Hex(gContext.mAgent.mPSKc.bin, OT_PSKC_LENGTH, gContext.mAgent.mPSKc.ascii);
+    }
+    otbrLog(OTBR_LOG_INFO, "pskc: %s", gContext.mAgent.mPSKc.ascii);
+    /* have a return here so this function matchs other "compute" functions */
+    return true; /* success */
+}
+
+/** compute the steering data */
+bool compute_steering(void)
+{
+    bool ok;
+
+    do
+    {
+        if (gContext.mJoiner.mAllowAny)
+        {
+            otbrLog(OTBR_LOG_INFO, "JOINER: Allow any ingore hashmac");
+            gContext.mJoiner.mSteeringData.Set();
+            ok = true;
+            break;
+        }
+
+        /* We require a hashmac */
+        ok = compute_hashmac();
+        if (!ok)
+        {
+            otbrLog(OTBR_LOG_INFO, "error: Cannot calculate steering data, bad hashmac");
+            break;
+        }
+
+        gContext.mJoiner.mSteeringData.Clear();
+        gContext.mJoiner.mSteeringData.ComputeBloomFilter(gContext.mJoiner.mHashMac.bin);
+
+
+    }
+    while (0);
+
+    /* log result */
+    if (ok)
+    {
+        int            n;
+        const uint8_t *pBytes;
+
+        n = gContext.mJoiner.mSteeringData.GetLength();
+
+        pBytes = gContext.mJoiner.mSteeringData.GetDataPointer();
+
+        otbrLog(OTBR_LOG_INFO, "steering-len: %d", n);
+        otbrLog(OTBR_LOG_INFO, "steering-hex: %s", hex_string(pBytes, n));
+    }
+    return ok;
+}

--- a/tests/meshcop/commissioner_selftest.cpp
+++ b/tests/meshcop/commissioner_selftest.cpp
@@ -49,21 +49,21 @@ static void test_pskc()
                   sizeof(gContext.mAgent.mXpanid.bin));
     if (n != sizeof(gContext.mAgent.mXpanid.bin))
     {
-        fail("cannot convert xpanid\n");
+        CommissionerUtilsFail("cannot convert xpanid\n");
     }
 
-    compute_pskc();
+    CommissionerComputePskc();
 
 
     static const uint8_t expected[] = {
         0xc3, 0xf5, 0x93, 0x68, 0x44, 0x5a, 0x1b, 0x61,
         0x06, 0xbe, 0x42, 0x0a, 0x70, 0x6d, 0x4c, 0xc9
     };
-    otbrLog(OTBR_LOG_INFO, "Expected: %s\n", hex_string(expected, sizeof(expected)));
+    otbrLog(OTBR_LOG_INFO, "Expected: %s\n", CommissionerUtilsHexString(expected, sizeof(expected)));
 
     if (0 != memcmp(expected, gContext.mAgent.mPSKc.bin, sizeof(expected)))
     {
-        fail("PSKC calculation fails test vector\n");
+        CommissionerUtilsFail("PSKC calculation fails test vector\n");
     }
     otbrLog(OTBR_LOG_INFO, "PSKC: test success\n");
 }
@@ -77,15 +77,15 @@ static void test_steering(void)
     gContext.mJoiner.mSteeringData.SetLength(15);
 
     strcpy(gContext.mJoiner.mEui64.ascii, "18b4300000000002");
-    ok = compute_hashmac();
+    ok = CommissionerComputeHashMac();
     if (!ok)
     {
-        fail("invalid hashmac\n");
+        CommissionerUtilsFail("invalid hashmac\n");
     }
-    ok = compute_steering();
+    ok = CommissionerComputeSteering();
     if (!ok)
     {
-        fail("Cannot compute steering\n");
+        CommissionerUtilsFail("Cannot compute steering\n");
     }
 
     const uint8_t expected[] = {
@@ -96,19 +96,19 @@ static void test_steering(void)
         0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x10,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
     };
-    otbrLog(OTBR_LOG_INFO, "expected: %s\n", hex_string(expected, sizeof(expected)));
+    otbrLog(OTBR_LOG_INFO, "expected: %s\n", CommissionerUtilsHexString(expected, sizeof(expected)));
     const uint8_t *pData;
     pData = gContext.mJoiner.mSteeringData.GetDataPointer();
 
     if (0 != memcmp(expected, pData, sizeof(expected)))
     {
-        fail("FAIL: Steering data");
+        CommissionerUtilsFail("FAIL: Steering data");
     }
     otbrLog(OTBR_LOG_INFO, "SUCCESS: Steering data\n");
 }
 
 /** the argcargv module calls this when the arg is found on the command line */
-void handle_selftest(argcargv *pThis)
+void CommissionerCmdLineSelfTest(argcargv *pThis)
 {
     (void)(pThis); /* not used */
     otbrLog(OTBR_LOG_INFO, "SELFTEST START\n");

--- a/tests/meshcop/commissioner_selftest.cpp
+++ b/tests/meshcop/commissioner_selftest.cpp
@@ -1,0 +1,121 @@
+/*
+ *    Copyright (c) 2017, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   The file test various computations used during commissioning.
+ */
+
+#include "commissioner.hpp"
+
+/* test the preshared key for commissioning */
+static void test_pskc()
+{
+    int n;
+
+    /* calculate PSKc -
+     * see spec section 8.4.1.2.2 Test Vector For Derivation of PSKc
+     */
+    strcpy(gContext.mAgent.mPassPhrase, "12SECRETPASSWORD34");
+    strcpy(gContext.mAgent.mNetworkName, "Test Network");
+    strcpy(gContext.mAgent.mXpanid.ascii, "0001020304050607");
+    n = Hex2Bytes(gContext.mAgent.mXpanid.ascii,
+                  gContext.mAgent.mXpanid.bin,
+                  sizeof(gContext.mAgent.mXpanid.bin));
+    if (n != sizeof(gContext.mAgent.mXpanid.bin))
+    {
+        fail("cannot convert xpanid\n");
+    }
+
+    compute_pskc();
+
+
+    static const uint8_t expected[] = {
+        0xc3, 0xf5, 0x93, 0x68, 0x44, 0x5a, 0x1b, 0x61,
+        0x06, 0xbe, 0x42, 0x0a, 0x70, 0x6d, 0x4c, 0xc9
+    };
+    otbrLog(OTBR_LOG_INFO, "Expected: %s\n", hex_string(expected, sizeof(expected)));
+
+    if (0 != memcmp(expected, gContext.mAgent.mPSKc.bin, sizeof(expected)))
+    {
+        fail("PSKC calculation fails test vector\n");
+    }
+    otbrLog(OTBR_LOG_INFO, "PSKC: test success\n");
+}
+
+/** test steering data */
+static void test_steering(void)
+{
+    bool ok;
+
+    gContext.mJoiner.mSteeringData.Clear();
+    gContext.mJoiner.mSteeringData.SetLength(15);
+
+    strcpy(gContext.mJoiner.mEui64.ascii, "18b4300000000002");
+    ok = compute_hashmac();
+    if (!ok)
+    {
+        fail("invalid hashmac\n");
+    }
+    ok = compute_steering();
+    if (!ok)
+    {
+        fail("Cannot compute steering\n");
+    }
+
+    const uint8_t expected[] = {
+        /* NOTE: this is an odd sized steering data
+         * it is valid, the steering data must be
+         * between 1 and 16 bytes, thus 15 is OK!
+         */
+        0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x10,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+    };
+    otbrLog(OTBR_LOG_INFO, "expected: %s\n", hex_string(expected, sizeof(expected)));
+    const uint8_t *pData;
+    pData = gContext.mJoiner.mSteeringData.GetDataPointer();
+
+    if (0 != memcmp(expected, pData, sizeof(expected)))
+    {
+        fail("FAIL: Steering data");
+    }
+    otbrLog(OTBR_LOG_INFO, "SUCCESS: Steering data\n");
+}
+
+/** the argcargv module calls this when the arg is found on the command line */
+void handle_selftest(argcargv *pThis)
+{
+    (void)(pThis); /* not used */
+    otbrLog(OTBR_LOG_INFO, "SELFTEST START\n");
+    test_pskc();
+    test_steering();
+
+    otbrLog(OTBR_LOG_INFO, "SUCCESS\n");
+    fprintf(stdout, "selftest: SUCCESS\n");
+    exit(EXIT_SUCCESS);
+}

--- a/tests/meshcop/commissioner_utils.cpp
+++ b/tests/meshcop/commissioner_utils.cpp
@@ -34,7 +34,7 @@
 #include "commissioner.hpp"
 
 /** return a hex string to print for logging */
-const char *hex_string(const uint8_t *pBytes, int n)
+const char *CommissionerUtilsHexString(const uint8_t *pBytes, int n)
 {
     static char buf[80 + 1];
 
@@ -49,7 +49,7 @@ const char *hex_string(const uint8_t *pBytes, int n)
 }
 
 /* die and exit */
-void fail(const char *fmt, ...)
+void CommissionerUtilsFail(const char *fmt, ...)
 {
     va_list ap;
 

--- a/tests/meshcop/commissioner_utils.cpp
+++ b/tests/meshcop/commissioner_utils.cpp
@@ -1,0 +1,67 @@
+/*
+ *    Copyright (c) 2017, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   Misc functions used by commissioning test app
+ */
+
+#include "commissioner.hpp"
+
+/** return a hex string to print for logging */
+const char *hex_string(const uint8_t *pBytes, int n)
+{
+    static char buf[80 + 1];
+
+    if (n > 40)
+    {
+        n = 40;
+    }
+
+
+    Bytes2Hex(pBytes, n, buf);
+    return buf;
+}
+
+/* die and exit */
+void fail(const char *fmt, ...)
+{
+    va_list ap;
+
+    va_start(ap, fmt);
+    otbrLogv(OTBR_LOG_ERR, fmt, ap);
+    va_end(ap);
+
+
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    va_end(ap);
+    fflush(stderr);
+
+    exit(EXIT_FAILURE);
+}

--- a/tests/meshcop/meshcop
+++ b/tests/meshcop/meshcop
@@ -714,5 +714,6 @@ joiner_start
 test_teardown
 
 # Great sucess!
-exit 0
+echo VERIFY THIS WORKED 
+exit 1
 

--- a/tests/meshcop/meshcop
+++ b/tests/meshcop/meshcop
@@ -29,6 +29,9 @@
 
 # Get our starting directory and remember it
 THIS_DIR=`pwd`
+echo "cwd: ${THIS_DIR}"
+echo "top_srcdir: ${top_srcdir}"
+echo "top_builddir: ${top_builddir}"
 
 # TRAVIS sets this variable
 if [ -z $TRAVIS ]
@@ -62,17 +65,14 @@ then
     echo "Travis build"
     # This is where the 'dist-check" is performed'
     # this is a source directory
-    ABS_BLD=`cd ${top_srcdir}    && pwd`
-    ABS_SRC=`cd ${top_srcdir}/.. && pwd`
-    
+    ABS_BLD=`${THIS_DIR}/${top_builddir} && pwd`
+    ABS_SRC=`${THIS_DIR}/${top_srcdir} && pwd`
 else
     echo "non-travis build"
     ABS_SRC=`cd ${THIS_DIR}/../.. && pwd`
     ABS_BLD=`cd ${THIS_DIR}/../.. && pwd`
 fi
-
-echo "top_srcdir=${top_srcdir}"
-echo "top_builddir=${top_builddir}"
+set +x
 echo "ABS_SRC=${ABS_SRC}"
 echo "ABS_BLD=${ABS_BLD}"
 

--- a/tests/meshcop/meshcop
+++ b/tests/meshcop/meshcop
@@ -27,16 +27,176 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-set -x
+# During development/test, running by hand, set this to true.
 
+DEBUG=true
+if $DEBUG
+then
+    top_srcdir=`cd ../.. && pwd`
+    top_builddir=`cd ../.. && pwd`
+fi
+
+THIS_DIR=`pwd`
+
+
+# in automated test mode, top_srcdir and top_builddir
+# macros are set globally by the build system (makefiles)
+
+# If invoked by hand .. they might not be
+# Thus, we verify they are correct.
+_f=$top_srcdir/src/agent/main.cpp
+if [ ! -f $_f ]
+then
+    echo "Variable: top_srcdir seems wrong, cannot find: $_f"
+    exit 1
+fi
+
+if [ x"$top_builddir" == x"" ]
+then
+    echo "Variable: top_srcdir is not set!"
+    exit 1
+fi    
+
+# this is the border router agent, it should have been built already
+_otbr_agent=otbr-agent
+OTBR_AGENT_EXE=$top_builddir/src/agent/$_otbr_agent
+
+# Verify that the ageint is present, and it is executable
+if [ ! -x $OTBR_AGENT_EXE ]
+then
+    echo "Missing otbr-agent: $OTBR_AGENT_EXE ..."
+    exit 1
+fi
+
+# We will be creating alot of log information
+# Rotate logs so we have a clean and empty set of logs uncluttered with other stuff
+if [ -f /etc/logrotate.conf ]
+then
+    sudo logrotate -f /etc/logrotate.conf
+fi
+
+# Common function to write to the syslog
+write_syslog()
+{
+    logger -p syslog.alert "OPENTHREAD_TEST: $@"
+}
+
+write_syslog "MESHCOP TEST BEGIN - rotated logs"
+
+# this is our quasi-install directory
 STAGE_DIR=/tmp/test-otbr-stage
+
+# We build wpantund & openthread here
 BUILD_DIR=/tmp/test-otbr-build
 
-OT_COMMISSIONER_APP=./otbr-commissioner
+# names for later use ..
+#   lower case: used by killall
+#   UPPER CASE: absolute path to the exe.
+_wpantund=wpantund
+WPANTUND_EXE=$STAGE_DIR/usr/sbin/$_wpantund
+_wpanctl=wpanctl
+WPANCTL_EXE=$STAGE_DIR/usr/bin/$_wpanctl
 
+# Once built, the NCP and CLI will be here
+# TODO (FUTURE): commission with ot-cli-mtd?
+_ot_ncp_xxx=ot-ncp-ftd
+NCP_EXE=$STAGE_DIR/usr/bin/$_ot_ncp_xxx
+_ot_cli_xxx=ot-cli-ftd
+CLI_EXE=$STAGE_DIR/usr/bin/$_ot_cli_xxx
+
+# this is the commissioner app (built in this directory)
+_otbr_commissioner=otbr-commissioner
+OTBR_COMMISSIONER_EXE=./$_otbr_commissioner
+
+# It should be built already
+if [ ! -x $OTBR_COMMISSIONER_EXE ]
+then
+    EXIT_MESSAGE="Missing otbr-commissioner: $OTBR_COMMISSIONER_EXE"
+    echo $EXIT_MESSAGE
+    exit 1
+fi
+
+
+# From now on - all exits are TRAPPED
+# When they occur, we call the function: output_logs'.
+
+trap 'output_logs' EXIT
+
+# We assume an unknown reason
+EXIT_MESSAGE=UNKNOWN_FAILURE
+
+output_logs()
+{
+    # Capture the exit code so we can return it below
+    EXITCODE=$?
+    
+    write_syslog "EXIT ${EXITCODE} - output logs"
+    # These may or may not have problems executing..
+    # So disable the simple exit flag.
+    set +e
+
+    # Kill all programs we execute and run
+    sudo killall $_wpantund
+
+    # This too, in case it is hung
+    sudo killall $_wpanctl
+    sudo killall $_otbr_agent
+    sudo killall $_otbr_commissioner
+
+    # Both ftd & mtd (future)
+    sudo killall $_ot_ncp_xxx
+    sudo killall $_ot_cli_xxx
+    sleep 1
+    write_syslog "All apps should be dead now"
+
+    # Wait 5 seconds for the "logs to flush"
+    sleep 5
+
+    # part 1
+    # ------
+    #
+    # On travis (the CI server), we can't see what went into the
+    # syslog.  So this is here so we can see the output.
+    #
+    # part 2
+    # ------
+    #
+    # If we run locally, it is sometimes helpful for our victim (you
+    # the developer) to have logs split upto various files to help
+    # that victim, we'll GREP the log files according.
+    #
+    echo "START_LOG: SYSLOG =========="
+    cat /var/log/syslog  | tee  complete-syslog.log
+    echo "START_LOG: BR-AGENT ========="
+    cat /var/log/syslog | grep $_otbr_agent | tee otbr-agent.log
+    echo "START_LOG: OTBR-COMISSIONER ========="
+    cat /var/log/syslog | grep $_otbr_commissioner | tee otbr-commissioner.log
+    echo "START_LOG: OT-NCP ========="
+    cat /var/log/syslog | grep $_ot_ncp_xxx | tee ${_ot_ncp_xxx}.log
+    echo "START_LOG: OT-CLI ========="
+    cat /var/log/syslog | grep $_ot_cli_xxx | tee ${_ot_cli_xxx}.log
+    echo "START_LOG: WPANTUND ======"
+    cat /var/log/syslog | grep $_wpantund | tee wpantund.log
+    echo "====================================="
+    echo "Hint, for each log Search backwards for: 'START_LOG: <NAME>'"
+    echo "====================================="
+    echo "EXIT ${EXIT_CODE}: MESSAGE: $EXIT_MESSAGE"
+    exit $EXIT_CODE
+}
+
+
+
+# our node ids..
 LEADER_NODE_NUMBER=1
 JOINER_NODE_NUMBER=2
 
+#----------------------------------------
+# TODO:
+#   Change these to random values
+#   so that we test with something other
+#   then the compiled in defaults.
+#----------------------------------------
+# the test panids
 OT_PANID=0xface
 OT_XPANID=1122334455667788
 #
@@ -49,11 +209,11 @@ OT_JOINER_PASSPHRASE=J01NER
 # 18b430 is the nest EUI prefix.
 OT_JOINER_EUI64=18b430000000000${JOINER_NODE_NUMBER}
 
-# Just some random hex numbers here
+# network master key
 OT_MASTER_KEY=00112233445566778899aabbccddeeff
 
 # We must pick a channel
-OT_CHANNEL=11
+OT_CHANNEL=22
 
 # And a prefix
 OT_GATEWAY=fd11:22::
@@ -68,10 +228,14 @@ OT_NETWORK_NAME=MyTestNetwork
 OT_AGENT_IPADDR=127.0.0.1
 OT_AGENT_IPPORT=49191
 
+# Optionally we can write the commisiner log to a file
 OT_COMMISSIONER_LOG_FILE=./otbr-commissioner-log.txt
 
-# Compute the PSKc from the above settings.
-_x=`$OT_COMMISSIONER_APP --disable-syslog --network-name $OT_NETWORK_NAME --xpanid $OT_XPANID --agent-passphrase $OT_AGENT_PASSPHRASE --compute-pskc`
+# Using the commissioner app - Compute the PSKc from the above settings.
+set -x
+_x=`$OTBR_COMMISSIONER_EXE --disable-syslog --network-name $OT_NETWORK_NAME --xpanid $OT_XPANID --agent-passphrase $OT_AGENT_PASSPHRASE --compute-pskc`
+set +x
+# And parse what we want from the output
 OT_PSKC=`echo $_x | cut -d ' ' -f2`
 
 # The TUN device for wpantund.
@@ -79,124 +243,378 @@ TUN_NAME=wpan9
 
 test_setup()
 {
+    # Clean up old stuff
     [ ! -d $STAGE_DIR ] || rm -rf $STAGE_DIR
     [ ! -d $BUILD_DIR ] || rm -rf $BUILD_DIR
+    mkdir -p $STAGE_DIR
     mkdir -p $BUILD_DIR
-    sudo cp $top_srcdir/src/agent/otbr-agent.conf /etc/dbus-1/system.d
+
+
+    _f=$top_srcdir/src/agent/otbr-agent.conf
+    if [ ! -f $_f ]
+    then
+	EXIT_MESSAGE="Missing: $_f"
+	echo $EXIT_MESSAGE
+	exit 1
+    fi
+    
+    sudo cp $_f /etc/dbus-1/system.d
 }
 
-
-fail() {
-    echo "================== SYSLOG ========================="
-    sudo cat /var/log/syslog
-    echo "==================================================="
-    echo "================== COMMISSIONER LOG ==============="
-    cat $OT_COMMISSIONER_LOG_FILE
-    echo "==================================================="
-    echo "TEST FAIL"
+checkout_wpantund()
+{
     set -e
-    exit 1
+
+    # git only checks out to empty directories..
+    rm -rf $BUILD_DIR/wpantund
+    
+    cd $BUILD_DIR
+    git clone --depth 1 https://github.com/openthread/wpantund.git
+
+    # boot strap
+    cd wpantund
+    set -x
+    ./bootstrap.sh
+    set +x
 }
 
-build_wpantund()
+configure_wpantund()
 {
-    (cd $BUILD_DIR &&
-        git clone --depth 1 https://github.com/openthread/wpantund.git &&
-        cd wpantund &&
-        ./bootstrap.sh &&
-        ./configure --prefix=/usr --sysconf=/etc --disable-ncp-dummy --enable-static-link-ncp-plugin=spinel &&
-        make install DESTDIR=$STAGE_DIR &&
-        $STAGE_DIR/usr/sbin/wpantund --version &&
-        sudo cp $STAGE_DIR/etc/dbus-1/system.d/wpantund.conf /etc/dbus-1/system.d)
+    set -e
+    
+    cd ${BUILD_DIR}/wpantund
+    set -x
+    ./configure --prefix=/usr --sysconf=/etc --disable-ncp-dummy --enable-static-link-ncp-plugin=spinel
+    set +x
 }
 
-build_openthread()
+compile_wpantund()
 {
-    (cd $BUILD_DIR &&
-        git clone --depth 1 https://github.com/openthread/openthread.git &&
-        cd openthread &&
-        ./bootstrap &&
-        ./configure --prefix=/usr         \
-        --disable-docs                    \
-        --enable-border-agent-proxy       \
-        --enable-cli-app=ftd              \
-        --enable-ncp-app=ftd              \
-        --enable-joiner                   \
-        --with-examples=posix             \
-        --with-ncp-bus=uart               \
-        --with-platform-info=POSIX &&     \
-        make install DESTDIR=$STAGE_DIR)
+    set -e
+    make -C ${BUILD_DIR}/wpantund all
+    make -C ${BUILD_DIR}/wpantund install DESTDIR=$STAGE_DIR
+
+    if [ ! -x $WPANTUND_EXE ]
+    then
+	EXIT_MESSAGE="Build failed, cannot find $WPANTUND_EXE"
+	echo $EXIT_MESSAGE
+	exit 1
+    fi
+
+    _f=$STAGE_DIR/etc/dbus-1/system.d/wpantund.conf
+    if [ ! -f $_f ]
+    then
+	EXIT_MESSAGE="Missing: $_f"
+	echo $EXIT_MESAGE
+	exit 1
+    fi
+    sudo cp $_f /etc/dbus-1/system.d
+
+    if [ -x /usr/sbin/service ]
+    then
+	# tell dbus to reload, we have changed/added a configuration file
+	sudo service dbus reload
+    else
+	write_syslog "WARNING: Do not know how to tell dbus to re-load config files"
+    fi
+    
 }
+
+recompile_wpantund()
+{
+    set -e
+    make -C ${BUILD_DIR}/wpantund  clean
+    compile_wpantund
+}
+
+recompile_openthread()
+{
+    set -e
+    make -C ${BUILD_DIR}/openthread clean
+    compile_openthread
+}
+
+
+checkout_openthread()
+{
+    set -e
+    cd $BUILD_DIR
+
+    # Git only checks out to empty directories.
+    rm -rf ${BUILD_DIR}/openthread
+    git clone --depth 1 https://github.com/openthread/openthread.git
+
+    # boot strap
+    cd openthread
+    ./bootstrap
+}
+
+compile_openthread()
+{
+    set -e
+    make -C ${BUILD_DIR}/openthread -j 20 all
+    make -C ${BUILD_DIR}/openthread -j 20 install DESTDIR=$STAGE_DIR
+}
+
+
+configure_openthread()
+{
+    set -e
+    set -x
+    # It is helpful to have logs enabled during testing ..
+    LOG_FLAGS=""
+    LOG_FLAGS="$LOG_FLAGS  -DOPENTHREAD_CONFIG_LOG_LEVEL=OT_LOG_LEVEL_DEBG"
+    LOG_FLAGS="$LOG_FLAGS  -DOPENTHREAD_CONFIG_LOG_API=1"
+    LOG_FLAGS="$LOG_FLAGS  -DOPENTHREAD_CONFIG_LOG_ARP=1"
+    LOG_FLAGS="$LOG_FLAGS  -DOPENTHREAD_CONFIG_LOG_CLI=1"
+    LOG_FLAGS="$LOG_FLAGS  -DOPENTHREAD_CONFIG_LOG_COAP=1"
+    LOG_FLAGS="$LOG_FLAGS  -DOPENTHREAD_CONFIG_LOG_ICMP=1"
+    LOG_FLAGS="$LOG_FLAGS  -DOPENTHREAD_CONFIG_LOG_IP6=1" 
+    LOG_FLAGS="$LOG_FLAGS  -DOPENTHREAD_CONFIG_LOG_MAC=1"
+    LOG_FLAGS="$LOG_FLAGS  -DOPENTHREAD_CONFIG_LOG_MEM=1"
+    LOG_FLAGS="$LOG_FLAGS  -DOPENTHREAD_CONFIG_LOG_MLE=1"
+    LOG_FLAGS="$LOG_FLAGS  -DOPENTHREAD_CONFIG_LOG_NETDATA=1"
+    LOG_FLAGS="$LOG_FLAGS  -DOPENTHREAD_CONFIG_LOG_NETDIAG=1"
+    LOG_FLAGS="$LOG_FLAGS  -DOPENTHREAD_CONFIG_LOG_PKT_DUMP=1"
+    LOG_FLAGS="$LOG_FLAGS  -DOPENTHREAD_CONFIG_LOG_PLATFORM=1"
+    LOG_FLAGS="$LOG_FLAGS  -DOPENTHREAD_CONFIG_LOG_PREPEND_LEVEL=1"
+    LOG_FLAGS="$LOG_FLAGS  -DOPENTHREAD_CONFIG_LOG_PREPEND_REGION=1"
+
+    CFLAGS="$CFLAGS $LOG_FLAGS"
+    CXXFLAGS="$CFLAGS $LOG_FLAGS"
+    export CFLAGS
+    export CXXFLAGS
+
+    cd ${BUILD_DIR}/openthread
+
+    # TODO: Should we test with 
+    ./configure --prefix=/usr                     \
+		--disable-docs                    \
+		--enable-tmf-proxy                \
+		--enable-border-router            \
+		--enable-cli-app=both             \
+		--enable-ncp-app=ftd              \
+		--enable-joiner                   \
+		--enable-debug                    \
+		--with-examples=posix             \
+		--with-ncp-bus=uart               \
+		--with-platform-info=POSIX
+    set +x
+}
+
 
 leader_start()
 {
-    set +e
-    sudo sh -s <<EOF
-    set -x
-    cd /tmp
-    $STAGE_DIR/usr/sbin/wpantund -d 5 -I $TUN_NAME -s "system:$STAGE_DIR/usr/bin/ot-ncp-ftd $LEADER_NODE_NUMBER" &
-    echo 'Waiting for wpantund to fully start'
-    sleep 5
-
-
-    sudo $STAGE_DIR/usr/bin/wpanctl -I $TUN_NAME setprop Daemon:AutoAssociateAfterReset false
-    sudo $STAGE_DIR/usr/bin/wpanctl -I $TUN_NAME leave
-    sudo $STAGE_DIR/usr/bin/wpanctl -I $TUN_NAME setprop Network:PSKc --data $OT_PSKC
-    sudo $STAGE_DIR/usr/bin/wpanctl -I $TUN_NAME setprop Network:Key --data $OT_MASTER_KEY
-    sudo $STAGE_DIR/usr/bin/wpanctl -I $TUN_NAME setprop Network:PANID $OT_PANID
-    sudo $STAGE_DIR/usr/bin/wpanctl -I $TUN_NAME setprop Network:XPANID $OT_XPANID
-    sudo $STAGE_DIR/usr/bin/wpanctl -I $TUN_NAME form $OT_NETWORK_NAME -c $OT_CHANNEL
-    sudo $STAGE_DIR/usr/bin/wpanctl -I $TUN_NAME config-gateway -d $OT_GATEWAY
-EOF
     set -e
+    if [ ! -x $NCP_EXE ]
+    then
+	EXIT_MESSAGE="Missing ncp: $NCP_EXE"
+	echo $EXIT_MESSAGE
+	exit 1
+    fi
+
+    if [ ! -x $CLI_EXE ]
+    then
+	EXIT_MESSAGE="MISSING cli: $CLI_EXE"
+	echo $EXIT_MESSAGE
+	exit 1
+    fi
+
+    if [ ! -x $WPANCTL_EXE ]
+    then
+	EXIT_MESSAGE="MISSING wpanctl: $WPANCTL_EXE"
+	echo $EXIT_MESSAGE
+	exit 1
+    fi
+
+    if [ ! -x $WPANTUND_EXE ]
+    then
+	EXIT_MESSAGE="MISSING wpantund: $WPANTUND_EXE"
+	echo $EXIT_MESSAGE
+	exit 1
+    fi
+
+    # These might not exit cleanly
+    set +e
+    write_syslog "LEADER: killing the old"
+    # Kill old wpantund
+    sudo killall $_wpantund
+    sudo killall $_ot_ncp_xxx
+    set -e
+
+    write_syslog "LEADER: starting"
+
+    # Do this within a private script as root.
+    sudo sh -s <<EOF
+    cd /tmp
+    set -e 
+    # We specifically put this in the background
+    set -x
+    $WPANTUND_EXE -d 5 -I $TUN_NAME -s "system:$NCP_EXE $LEADER_NODE_NUMBER" &
+    echo 'Waiting for wpantund to fully start'
+    sleep 10
+
+    sudo $WPANCTL_EXE -I $TUN_NAME setprop Daemon:AutoAssociateAfterReset false
+    sudo $WPANCTL_EXE -I $TUN_NAME leave
+    sudo $WPANCTL_EXE -I $TUN_NAME setprop Network:PSKc --data $OT_PSKC
+    sudo $WPANCTL_EXE -I $TUN_NAME setprop Network:Key --data $OT_MASTER_KEY
+    sudo $WPANCTL_EXE -I $TUN_NAME setprop Network:PANID $OT_PANID
+    sudo $WPANCTL_EXE -I $TUN_NAME setprop Network:XPANID $OT_XPANID
+    sudo $WPANCTL_EXE -I $TUN_NAME form $OT_NETWORK_NAME -c $OT_CHANNEL
+    sudo $WPANCTL_EXE -I $TUN_NAME config-gateway -d $OT_GATEWAY
+    set +x
+EOF
+    # Wait for wpantund to complete
+    sleep 10
+
+    # These should be running now
+    # And should not have crashed!
+    pidof $_wpantund
+    if [ $? != 0 ]
+    then
+	EXIT_MESSAGE="LEADER: Failed to start wpantund"
+	echo $EXIT_MESSAGE
+	exit 1
+    fi
+    pidof $_ot_ncp_xxx
+    if [ $? != 0 ]
+    then
+	EXIT_MESSAGE="LEADER: Failed to start $_ot_ncp_xxx"
+	echo $EXIT_MESSAGE
+	exit 1
+    fi
+    
+    write_syslog "LEADER: start complete"
 }
+
 
 ba_start()
 {
-    sudo $top_builddir/src/agent/otbr-agent -I $TUN_NAME &
-    echo 'Waiting for border agent start'
-    sleep 5
+    set -e
+    if [ ! -x $OTBR_AGENT_EXE ]
+    then
+	EXIT_MESSAGE="Missing: otbr-agent: $OTBR_AGENT_EXE"
+	echo $EXIT_MESSAGE
+	exit 1
+    fi
+    set +e
+    write_syslog "AGENT: kill old"
+    sudo killall $_otbr_agent
+    set -e
+    write_syslog "AGENT: starting"
+
+    # we launch this in the background
+    set -x
+    cd $THIS_DIR
+    sudo $OTBR_AGENT_EXE -I $TUN_NAME &
+    set +x
+    # wait for it to complete
+    sleep 10
+
+    pidof $_otbr_agent
+    if [ $? != 0 ]
+    then
+	EXIT_MESSAGE="AGENT: failed to start"
+	echo $EXIT_MESSAGE
+	exit 1
+    fi
+    
+    write_syslog "AGENT: start complete"
 }
 
 commissioner_start()
 {
+    set -e
+
+    if [ ! -x $OTBR_COMMISSIONER_EXE ]
+    then
+	EXIT_MESSAGE="Missing otbr-commissioner: $OTBR_COMMISSIONER_EXE"
+	echo $EXIT_MESSAGE
+	exit 1
+    fi
+    
+    write_syslog "COMMISSIONER: kill old"
+    set +e
+    sudo killall $_otbr_commissioner
+    set -e
+
+    set -x
+    # Clear the ARGS variable.
     ARGS=""
-    # We'll create our own logfile and not use the syslog
-    ARGS="$ARGS --disable-syslog"
-    # Our log file.
-    ARGS="$ARGS --log-filename $OT_COMMISSIONER_LOG_FILE"
+    # OPTIONALLY we can create our own logfile and not use the syslog
+    #ARGS="$ARGS --disable-syslog"
+    #ARGS="$ARGS --log-filename $OT_COMMISSIONER_LOG_FILE"
+
+    rm -f $OT_COMMISSIONER_LOG_FILE
+    
     # And network parameters
     ARGS="$ARGS --network-name      $OT_NETWORK_NAME"
     ARGS="$ARGS --xpanid            $OT_XPANID"
     ARGS="$ARGS --agent-passphrase  $OT_AGENT_PASSPHRASE"
     # About our joiner.
     ARGS="$ARGS --joiner-eui64      $OT_JOINER_EUI64"
-    AGGS="$ARGS --joiner-passphrase $OT_JOINER_PASSPHRASE"
+    ARGS="$ARGS --joiner-passphrase $OT_JOINER_PASSPHRASE"
     # Where is the agent?
     ARGS="$ARGS --agent-addr        $OT_AGENT_IPADDR"
     ARGS="$ARGS --agent-port        $OT_AGENT_IPPORT"
+    #
+    # Debug level, full blast (this is test a test on a
+    # a remote machine, being able to *SEE* the result helpful
+    ARGS="$ARGS --debug-level 7"
+
+    # All of this should be done in 200 seconds
+    # See note below about COMM_KA
+    ARGS="$ARGS --comm-envelope-timeout 200"
+
     # Tell the tool to "commission"
     ARGS="$ARGS --commission-device"
 
     # Launch the commissioner in the background
-    $OT_COMMISSIONER_APP $ARGS &
+    set -x
+    cd $THIS_DIR
+    $OTBR_COMMISSIONER_EXE $ARGS &
+    # Wait for it to launch and get started.
+    sleep 5
+    set x
+
+    # Is it still running or did it die?
+    set +x
+    pidof $_otbr_commissioner
     if [ $? != 0 ]
     then
-	fail()
+	EXIT_MESSAGE="COMMISSIONER: failed to start"
+	echo $EXIT_MESSAGE
 	exit 1
     fi
     #
     # It takes about 8 to 10 seconds for the DTLS handshake to complete.
     echo 'Waiting for commissioner'
-    sleep 20
+
+    # The ENVELOPE (total time) timeout is 200 seconds.
+    #
+    # If no COMM_KA occurs:
+    #    The Commissioner process timeout is 50 seconds.
+    # ELSE
+    #    (COMM_KA does occur)
+    #    The commissioner will not timeout
+    #
+    # By waiting 100 seconds we test that the timeout would have fired
+    # And that the COMM_KA process is actually working.
+    #
+    sleep 100
+    write_syslog "TEST: Commissioner COM_KA should be seen by now"
+    write_syslog "TEST: Commissioner ready for joiner"
     return 0
 }
 
 joiner_start()
 {
+    write_syslog "JOINER START"
     cd /tmp
+    # do not die on simple errors here
+    set +e
     expect -f- <<EOF
-spawn $STAGE_DIR/usr/bin/ot-cli-ftd $JOINER_NODE_NUMBER
+spawn $CLI_EXE $JOINER_NODE_NUMBER
 send "ifconfig up\r\n"
 expect "Done"
 send "joiner start $OT_JOINER_PASSPHRASE\r\n"
@@ -210,34 +628,58 @@ expect {
   }
 }
 EOF
-    exitcode=$?
-    cd -
-    return $?
+    if [ $1 != 0 ]
+    then
+	EXIT_MESSAGE="JOINER FAILED"
+	echo $EXIT_MESSAGE
+	exit 1
+    fi
+    # We are happy!
+    EXIT_MESSAGE="JOINER SUCCESS COMPLETE"
+    echo $EXIT_MESSAGE
 }
 
 test_teardown()
 {
     # Do not die on simple errors
     set +e
+    cd $THIS_DIR
     echo 'clearing all'
     sudo rm /etc/dbus-1/system.d/wpantund.conf
     sudo rm /etc/dbus-1/system.d/otbr-agent.conf
     sudo rm -rf $STAGE_DIR
-    sudo killall wpantund
-    sudo killall otbr-agent
-    sudo killall otbr-commissioner
+    sudo rm -rf $BUILD_DIR
+    sudo killall $_wpantund
+    sudo killall $_wpanctl
+    sudo killall $_otbr_agent
+    sudo killall $_otbr_commissioner
+    sudo killall $_ot_ncp_xxx
+    sudo killall $_ot_cli_xxx
     wait
 }
 
 test_setup
-build_wpantund
-build_openthread
-leader_start  || fail
-ba_start || fail
-commissioner_start || fail
-joiner_start || fail
+    
+# These are broken-out so that during debug you can comment out parts
+# and re-run this script multiple times script and not have your
+# test code get erased ...
+checkout_wpantund
+configure_wpantund
+recompile_wpantund
+
+# As above, these steps are broken up
+checkout_openthread
+configure_openthread
+recompile_openthread
+
+write_syslog "TEST: BUILD COMPLETE"
+
+leader_start
+ba_start
+commissioner_start
+joiner_start
 test_teardown
 
-exit 1
+# Great sucess!
+exit 0
 
-exit $EXIT_CODE

--- a/tests/meshcop/meshcop
+++ b/tests/meshcop/meshcop
@@ -669,7 +669,8 @@ EOF
     fi
     # We are happy!
     EXIT_MESSAGE="JOINER SUCCESS COMPLETE"
-    echo $EXIT_MESSAGE
+    # we do not exit here!
+    # Save that for after we cleanup
 }
 
 test_teardown()

--- a/tests/meshcop/meshcop
+++ b/tests/meshcop/meshcop
@@ -48,6 +48,12 @@ _f=$top_srcdir/src/agent/main.cpp
 if [ ! -f $_f ]
 then
     echo "Variable: top_srcdir seems wrong, cannot find: $_f"
+    ls -l $top_srcdir
+    echo "BUILD DIR is:"
+    ls -l $top_builddir
+    echo "VARIABLES ARE:"
+    set
+ 
     exit 1
 fi
 

--- a/tests/meshcop/meshcop
+++ b/tests/meshcop/meshcop
@@ -78,7 +78,7 @@ test_setup()
     [ ! -d $STAGE_DIR ] || rm -rf $STAGE_DIR
     [ ! -d $BUILD_DIR ] || rm -rf $BUILD_DIR
     mkdir -p $BUILD_DIR
-    sudo cp $top_srcdir/src/border-agent/otbr-agent.conf /etc/dbus-1/system.d
+    sudo cp $top_srcdir/src/agent/otbr-agent.conf /etc/dbus-1/system.d
 }
 
 build_wpantund()

--- a/tests/meshcop/meshcop
+++ b/tests/meshcop/meshcop
@@ -155,13 +155,15 @@ commissioner_start()
     # About our joiner.
     ARGS="$ARGS --joiner-eui64      $OT_JOINER_EUI64"
     AGGS="$ARGS --joiner-passphrase $OT_JOINER_PASSPHRASE"
+    # Tell the tool to "commission"
+    ARGS="$ARGS --commission-device"
 
     # Launch the commissioner in the background
     $OT_COMMISSIONER_APP $ARGS &
     if [ $? != 0 ]
     then
 	echo "FAILURE"
-	return 1
+	exit 1
     fi
     #
     # It takes about 8 to 10 seconds for the DTLS handshake to complete.
@@ -207,20 +209,7 @@ test_teardown()
     wait
 }
 
-# Die/Exit on any simple failure
-set -e
-test_setup
-build_wpantund
-build_openthread
-leader_start
-ba_start
-commissioner_start
-joiner_start
-EXIT_CODE=$?
-test_teardown
-
-if [ $EXIT_CODE != 0 ]
-then
+fail() {
     echo "================== SYSLOG ========================="
     sudo cat /var/log/syslog
     echo "==================================================="
@@ -228,15 +217,19 @@ then
     cat $OT_COMMISSIONER_LOG_FILE
     echo "==================================================="
     echo "TEST FAIL"
-else
-    echo "TEST SUCCESS"
-fi
+    set -e
+    exit 1
+}
 
+test_setup
+build_wpantund
+build_openthread
+leader_start  || fail
+ba_start || fail
+commissioner_start || fail
+joiner_start || fail
+test_teardown
 
-echo "================== COMMISSIONER LOG ==============="
-cat $OT_COMMISSIONER_LOG_FILE
-echo "==================================================="
-echo "PURPOSELY FAIL TO TEST IF THIS IS CAUGHT and to examine the test results"
 exit 1
 
 exit $EXIT_CODE

--- a/tests/meshcop/meshcop
+++ b/tests/meshcop/meshcop
@@ -30,8 +30,7 @@
 # Get our starting directory and remember it
 THIS_DIR=`pwd`
 
-# Assume TRAVIS has set this variable
-set -x
+# TRAVIS sets this variable
 if [ -z $TRAVIS ]
 then
     # If not, then set it for us
@@ -39,8 +38,9 @@ then
     # or running this script manually
     TRAVIS=false
 fi
-set +x
+
 # get our ABS locations.
+set -x
 if $TRAVIS
 then
     # TRAVIS NOTE:
@@ -58,12 +58,19 @@ then
     # you would think $top_srcdir=/home/travis/build/openthread/borderrouter/otbr-gaac8ffa-dirty
     # but we get:     $top_srcdir=/home/travis/build/openthread/borderrouter/otbr-gaac8ffa-dirty/_build
     #
+    echo "Travis build"
     ABS_SRC=`cd ${top_srcdir}/.. && pwd`
     ABS_BLD=`cd ${top_srcdir}    && pwd`
 else
-    ABS_SRC=`cd ../.. && pwd`
-    ABS_BLD=`cd ../.. && pwd`
+    echo "non-travis build"
+    ABS_SRC=`cd ${THIS_DIR}/../.. && pwd`
+    ABS_BLD=`cd ${THIS_DIR}/../.. && pwd`
 fi
+
+echo "top_srcdir=${top_srcdir}"
+echo "top_builddir=${top_builddir}"
+echo "ABS_SRC=${ABS_SRC}"
+echo "ABS_BLD=${ABS_BLD}"
 
 # Verify things are present
 _f=${ABS_SRC}/src/agent/main.cpp
@@ -74,7 +81,7 @@ then
 fi
 
 find $ABS_BLD -type f -print
-
+set +x
 # What we care about is the AGENT
 #
 # this is the border router agent, it should have been built already

--- a/tests/meshcop/meshcop
+++ b/tests/meshcop/meshcop
@@ -29,6 +29,9 @@
 
 set -x
 
+echo "PURPOSELY FAIL TO TEST IF THIS IS CAUGHT"
+exit 1
+
 STAGE_DIR=/tmp/test-otbr-stage
 BUILD_DIR=/tmp/test-otbr-build
 

--- a/tests/meshcop/meshcop
+++ b/tests/meshcop/meshcop
@@ -32,14 +32,46 @@ set -x
 STAGE_DIR=/tmp/test-otbr-stage
 BUILD_DIR=/tmp/test-otbr-build
 
+OT_COMMISSIONER_APP=./otbr-commissioner
+
+LEADER_NODE_NUMBER=1
+JOINER_NODE_NUMBER=2
+
 OT_PANID=0xface
 OT_XPANID=1122334455667788
-OT_PSKC=ee49a905637bbe2608dde3dc3576e188
-OT_JOINER_PASSWORD=123456
+#
+# NOTE Joiner pass phrase:
+#   Must be at least 6 bytes long
+#   And this example has: J ZERO ONE N E R
+#   We cannot use letter O and I because Q O I Z are not allowed per spec
+OT_JOINER_PASSPHRASE=J01NER
+
+# 18b430 is the nest EUI prefix.
+OT_JOINER_EUI64=18b430000000000${JOINER_NODE_NUMBER}
+
+# Just some random hex numbers here
 OT_MASTER_KEY=00112233445566778899aabbccddeeff
+
+# We must pick a channel
 OT_CHANNEL=11
+
+# And a prefix
 OT_GATEWAY=fd11:22::
 
+# The border agent, and ncp needs a pass phrase.
+OT_AGENT_PASSPHRASE=MYPASSPHRASE
+
+# The network needs a name.
+OT_NETWORK_NAME=MyTestNetwork
+
+OT_COMMISSIONER_LOG_FILE=./otbr-commissioner-log.txt
+
+
+# Compute the PSKc from the above settings.
+_x=`$OT_COMMISSIONER_APP --disable-syslog --network-name $OT_NETWORK_NAME --xpanid $OT_XPANID --agent-passphrase $OT_AGENT_PASSPHRASE --compute-pskc`
+OT_PSKC=`echo $_x | cut -d ' ' -f2`
+
+# The TUN device for wpantund.
 TUN_NAME=wpan9
 
 test_setup()
@@ -83,7 +115,7 @@ leader_start()
 {
     sudo sh -s <<EOF
     cd /tmp
-    $STAGE_DIR/usr/sbin/wpantund -I $TUN_NAME -s "system:$STAGE_DIR/usr/bin/ot-ncp-ftd 1" &
+    $STAGE_DIR/usr/sbin/wpantund -I $TUN_NAME -s "system:$STAGE_DIR/usr/bin/ot-ncp-ftd $LEADER_NODE_NUMBER" &
     echo 'Waiting for wpantund to fully start'
     sleep 5
 
@@ -93,7 +125,7 @@ leader_start()
     sudo $STAGE_DIR/usr/bin/wpanctl -I $TUN_NAME setprop Network:Key --data $OT_MASTER_KEY
     sudo $STAGE_DIR/usr/bin/wpanctl -I $TUN_NAME setprop Network:PANID $OT_PANID
     sudo $STAGE_DIR/usr/bin/wpanctl -I $TUN_NAME setprop Network:XPANID $OT_XPANID
-    sudo $STAGE_DIR/usr/bin/wpanctl -I $TUN_NAME form OpenThread -c $OT_CHANNEL
+    sudo $STAGE_DIR/usr/bin/wpanctl -I $TUN_NAME form $OT_NETWORK_NAME -c $OT_CHANNEL
     sudo $STAGE_DIR/usr/bin/wpanctl -I $TUN_NAME config-gateway -d $OT_GATEWAY
 EOF
 }
@@ -107,8 +139,24 @@ ba_start()
 
 commissioner_start()
 {
-    ./otbr-commissioner $OT_PSKC &
-    echo 'Waitint for commissioner'
+    ARGS=""
+    # We'll create our own logfile and not use the syslog
+    ARGS="$ARGS --disable-syslog"
+    # Our log file.
+    ARGS="$ARGS --logfile $OT_COMMISSIONER_LOG_FILE"
+    # And network parameters
+    ARGS="$ARGS --network-name      $OT_NETWORK_NAME"
+    ARGS="$ARGS --xpanid            $OT_XPANID"
+    ARGS="$ARGS --agent-passphrase  $OT_AGENT_PASSPHRASE"
+    # About our joiner.
+    ARGS="$ARGS --joiner-eui64      $OT_JOINER_EUI64"
+    AGGS="$ARGS --joiner-passphrase $OT_JOINER_PASSPHRASE"
+
+    # Launch the commissioner in the background
+    $OT_COMMISSIONER_APP $ARGS &
+    #
+    # It takes about 8 to 10 seconds for the DTLS handshake to complete.
+    echo 'Waiting for commissioner'
     sleep 20
 }
 
@@ -116,7 +164,7 @@ joiner_start()
 {
     cd /tmp
     expect -f- <<EOF
-spawn $STAGE_DIR/usr/bin/ot-cli-ftd 2
+spawn $STAGE_DIR/usr/bin/ot-cli-ftd $JOINER_NODE_NUMBER
 send "ifconfig up\r\n"
 expect "Done"
 send "joiner start $OT_JOINER_PASSWORD\r\n"
@@ -154,4 +202,18 @@ commissioner_start
 joiner_start
 EXIT_CODE=$?
 test_teardown
+
+if [ $EXIT_CODE != 0 ]
+then
+    echo "================== SYSLOG ========================="
+    sudo cat /var/log/syslog
+    echo "==================================================="
+    echo "================== COMMISSIONER LOG ==============="
+    cat $OT_COMMISSIONER_LOG_FILE
+    echo "==================================================="
+    echo "TEST FAIL"
+else
+    echo "TEST SUCCESS"
+fi
+
 exit $EXIT_CODE

--- a/tests/meshcop/meshcop
+++ b/tests/meshcop/meshcop
@@ -722,6 +722,6 @@ joiner_start
 test_teardown
 
 # Great sucess!
-echo VERIFY THIS WORKED 
-exit 1
+IS_SUCCESS=true
+exit 0
 

--- a/tests/meshcop/meshcop
+++ b/tests/meshcop/meshcop
@@ -100,6 +100,7 @@ build_openthread()
         cd openthread &&
         ./bootstrap &&
         ./configure --prefix=/usr         \
+        --disable-docs                    \		    
         --enable-border-agent-proxy       \
         --enable-cli-app=ftd              \
         --enable-ncp-app=ftd              \
@@ -112,11 +113,14 @@ build_openthread()
 
 leader_start()
 {
+    set +e
     sudo sh -s <<EOF
+    set -x
     cd /tmp
-    $STAGE_DIR/usr/sbin/wpantund -I $TUN_NAME -s "system:$STAGE_DIR/usr/bin/ot-ncp-ftd $LEADER_NODE_NUMBER" &
+    $STAGE_DIR/usr/sbin/wpantund -d 5 -I $TUN_NAME -s "system:$STAGE_DIR/usr/bin/ot-ncp-ftd $LEADER_NODE_NUMBER" &
     echo 'Waiting for wpantund to fully start'
     sleep 5
+
 
     sudo $STAGE_DIR/usr/bin/wpanctl -I $TUN_NAME setprop Daemon:AutoAssociateAfterReset false
     sudo $STAGE_DIR/usr/bin/wpanctl -I $TUN_NAME leave
@@ -127,6 +131,7 @@ leader_start()
     sudo $STAGE_DIR/usr/bin/wpanctl -I $TUN_NAME form $OT_NETWORK_NAME -c $OT_CHANNEL
     sudo $STAGE_DIR/usr/bin/wpanctl -I $TUN_NAME config-gateway -d $OT_GATEWAY
 EOF
+    set -e
 }
 
 ba_start()

--- a/tests/meshcop/meshcop
+++ b/tests/meshcop/meshcop
@@ -100,7 +100,7 @@ build_openthread()
         cd openthread &&
         ./bootstrap &&
         ./configure --prefix=/usr         \
-        --disable-docs                    \		    
+        --disable-docs                    \
         --enable-border-agent-proxy       \
         --enable-cli-app=ftd              \
         --enable-ncp-app=ftd              \

--- a/tests/meshcop/meshcop
+++ b/tests/meshcop/meshcop
@@ -64,6 +64,10 @@ OT_AGENT_PASSPHRASE=MYPASSPHRASE
 # The network needs a name.
 OT_NETWORK_NAME=MyTestNetwork
 
+# The agent is on the local host.
+OT_AGENT_IPADDR=127.0.0.1
+OT_AGENT_IPPORT=49191
+
 OT_COMMISSIONER_LOG_FILE=./otbr-commissioner-log.txt
 
 # Compute the PSKc from the above settings.
@@ -79,6 +83,19 @@ test_setup()
     [ ! -d $BUILD_DIR ] || rm -rf $BUILD_DIR
     mkdir -p $BUILD_DIR
     sudo cp $top_srcdir/src/agent/otbr-agent.conf /etc/dbus-1/system.d
+}
+
+
+fail() {
+    echo "================== SYSLOG ========================="
+    sudo cat /var/log/syslog
+    echo "==================================================="
+    echo "================== COMMISSIONER LOG ==============="
+    cat $OT_COMMISSIONER_LOG_FILE
+    echo "==================================================="
+    echo "TEST FAIL"
+    set -e
+    exit 1
 }
 
 build_wpantund()
@@ -155,6 +172,9 @@ commissioner_start()
     # About our joiner.
     ARGS="$ARGS --joiner-eui64      $OT_JOINER_EUI64"
     AGGS="$ARGS --joiner-passphrase $OT_JOINER_PASSPHRASE"
+    # Where is the agent?
+    ARGS="$ARGS --agent-addr        $OT_AGENT_IPADDR"
+    ARGS="$ARGS --agent-port        $OT_AGENT_IPPORT"
     # Tell the tool to "commission"
     ARGS="$ARGS --commission-device"
 
@@ -162,7 +182,7 @@ commissioner_start()
     $OT_COMMISSIONER_APP $ARGS &
     if [ $? != 0 ]
     then
-	echo "FAILURE"
+	fail()
 	exit 1
     fi
     #
@@ -207,18 +227,6 @@ test_teardown()
     sudo killall otbr-agent
     sudo killall otbr-commissioner
     wait
-}
-
-fail() {
-    echo "================== SYSLOG ========================="
-    sudo cat /var/log/syslog
-    echo "==================================================="
-    echo "================== COMMISSIONER LOG ==============="
-    cat $OT_COMMISSIONER_LOG_FILE
-    echo "==================================================="
-    echo "TEST FAIL"
-    set -e
-    exit 1
 }
 
 test_setup

--- a/tests/meshcop/meshcop
+++ b/tests/meshcop/meshcop
@@ -27,6 +27,8 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
+IS_SUCCESS=false
+
 # Get our starting directory and remember it
 THIS_DIR=`pwd`
 echo "cwd: ${THIS_DIR}"
@@ -214,7 +216,12 @@ output_logs()
     echo "Hint, for each log Search backwards for: 'START_LOG: <NAME>'"
     echo "====================================="
     echo "EXIT ${EXIT_CODE}: MESSAGE: $EXIT_MESSAGE"
-    exit $EXIT_CODE
+    if $IS_SUCCESS
+    then
+	exit 0
+    else
+	exit 1
+    fi
 }
 
 

--- a/tests/meshcop/meshcop
+++ b/tests/meshcop/meshcop
@@ -142,7 +142,7 @@ commissioner_start()
     # We'll create our own logfile and not use the syslog
     ARGS="$ARGS --disable-syslog"
     # Our log file.
-    ARGS="$ARGS --logfile $OT_COMMISSIONER_LOG_FILE"
+    ARGS="$ARGS --log-filename $OT_COMMISSIONER_LOG_FILE"
     # And network parameters
     ARGS="$ARGS --network-name      $OT_NETWORK_NAME"
     ARGS="$ARGS --xpanid            $OT_XPANID"
@@ -153,10 +153,16 @@ commissioner_start()
 
     # Launch the commissioner in the background
     $OT_COMMISSIONER_APP $ARGS &
+    if [ $? != 0 ]
+    then
+	echo "FAILURE"
+	return 1
+    fi
     #
     # It takes about 8 to 10 seconds for the DTLS handshake to complete.
     echo 'Waiting for commissioner'
     sleep 20
+    return 0
 }
 
 joiner_start()
@@ -166,7 +172,7 @@ joiner_start()
 spawn $STAGE_DIR/usr/bin/ot-cli-ftd $JOINER_NODE_NUMBER
 send "ifconfig up\r\n"
 expect "Done"
-send "joiner start $OT_JOINER_PASSWORD\r\n"
+send "joiner start $OT_JOINER_PASSPHRASE\r\n"
 set timeout 20
 expect {
   "Join success" {
@@ -177,11 +183,15 @@ expect {
   }
 }
 EOF
+    exitcode=$?
     cd -
+    return $?
 }
 
 test_teardown()
 {
+    # Do not die on simple errors
+    set +e
     echo 'clearing all'
     sudo rm /etc/dbus-1/system.d/wpantund.conf
     sudo rm /etc/dbus-1/system.d/otbr-agent.conf
@@ -192,6 +202,8 @@ test_teardown()
     wait
 }
 
+# Die/Exit on any simple failure
+set -e
 test_setup
 build_wpantund
 build_openthread

--- a/tests/meshcop/meshcop
+++ b/tests/meshcop/meshcop
@@ -58,9 +58,13 @@ then
     # you would think $top_srcdir=/home/travis/build/openthread/borderrouter/otbr-gaac8ffa-dirty
     # but we get:     $top_srcdir=/home/travis/build/openthread/borderrouter/otbr-gaac8ffa-dirty/_build
     #
+    #-----
     echo "Travis build"
-    ABS_SRC=`cd ${top_srcdir}/.. && pwd`
+    # This is where the 'dist-check" is performed'
+    # this is a source directory
     ABS_BLD=`cd ${top_srcdir}    && pwd`
+    ABS_SRC=`cd ${top_srcdir}/.. && pwd`
+    
 else
     echo "non-travis build"
     ABS_SRC=`cd ${THIS_DIR}/../.. && pwd`

--- a/tests/meshcop/meshcop
+++ b/tests/meshcop/meshcop
@@ -29,9 +29,6 @@
 
 set -x
 
-echo "PURPOSELY FAIL TO TEST IF THIS IS CAUGHT"
-exit 1
-
 STAGE_DIR=/tmp/test-otbr-stage
 BUILD_DIR=/tmp/test-otbr-build
 
@@ -68,7 +65,6 @@ OT_AGENT_PASSPHRASE=MYPASSPHRASE
 OT_NETWORK_NAME=MyTestNetwork
 
 OT_COMMISSIONER_LOG_FILE=./otbr-commissioner-log.txt
-
 
 # Compute the PSKc from the above settings.
 _x=`$OT_COMMISSIONER_APP --disable-syslog --network-name $OT_NETWORK_NAME --xpanid $OT_XPANID --agent-passphrase $OT_AGENT_PASSPHRASE --compute-pskc`
@@ -218,5 +214,12 @@ then
 else
     echo "TEST SUCCESS"
 fi
+
+
+echo "================== COMMISSIONER LOG ==============="
+cat $OT_COMMISSIONER_LOG_FILE
+echo "==================================================="
+echo "PURPOSELY FAIL TO TEST IF THIS IS CAUGHT and to examine the test results"
+exit 1
 
 exit $EXIT_CODE

--- a/tests/meshcop/meshcop
+++ b/tests/meshcop/meshcop
@@ -27,45 +27,57 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-# During development/test, running by hand, set this to true.
-
-DEBUG=true
-if $DEBUG
-then
-    top_srcdir=`cd ../.. && pwd`
-    top_builddir=`cd ../.. && pwd`
-fi
-
+# Get our starting directory and remember it
 THIS_DIR=`pwd`
 
+# Assume TRAVIS has set this variable
+if [ x"$TRAVIS" == x"" ]
+then
+    # If not, then set it for us
+    # for example you might be debugging
+    # or running this script manually
+    TRAVIS=false
+fi
 
-# in automated test mode, top_srcdir and top_builddir
-# macros are set globally by the build system (makefiles)
+# get our ABS locations.
+if $TRAVIS
+then
+    # TRAVIS NOTE:
+    #   Travis builds with  src != cwd
+    #
+    #   However, we don't seem to get the correct variables as you would expect
+    #
+    # What we do get is this (example):
+    #
+    # CWD: THIS_DIR='/home/travis/build/openthread/borderrouter/otbr-gaac8ffa-dirty/_build/tests/meshcop'
+    # srcdir='../../../tests/meshcop'
+    # top_builddir='/home/travis/build/openthread/borderrouter/otbr-gaac8ffa-dirty/_build'
+    # top_srcdir='/home/travis/build/openthread/borderrouter/otbr-gaac8ffa-dirty/_build'
+    #
+    # you would think $top_srcdir=/home/travis/build/openthread/borderrouter/otbr-gaac8ffa-dirty
+    # but we get:     $top_srcdir=/home/travis/build/openthread/borderrouter/otbr-gaac8ffa-dirty/_build
+    #
+    ABS_SRC=`cd ${top_srcdir}/.. && pwd`
+    ABS_BLD=`cd ${top_srcdir}    && pwd`
+else
+    ABS_SRC=`cd ../.. && pwd`
+    ABS_BLD=`cd ../.. && pwd`
+fi
 
-# If invoked by hand .. they might not be
-# Thus, we verify they are correct.
-_f=$top_srcdir/src/agent/main.cpp
+# Verify things are present
+_f=${ABS_SRC}/src/agent/main.cpp
 if [ ! -f $_f ]
 then
-    echo "Variable: top_srcdir seems wrong, cannot find: $_f"
-    ls -l $top_srcdir
-    echo "BUILD DIR is:"
-    ls -l $top_builddir
-    echo "VARIABLES ARE:"
-    set
- 
+    echo "MISSING: $_f"
     exit 1
 fi
 
-if [ x"$top_builddir" == x"" ]
-then
-    echo "Variable: top_srcdir is not set!"
-    exit 1
-fi    
-
+# What we care about is the AGENT
+#
 # this is the border router agent, it should have been built already
 _otbr_agent=otbr-agent
-OTBR_AGENT_EXE=$top_builddir/src/agent/$_otbr_agent
+OTBR_AGENT_EXE=$ABS_BLD/src/agent/$_otbr_agent
+
 
 # Verify that the ageint is present, and it is executable
 if [ ! -x $OTBR_AGENT_EXE ]
@@ -256,7 +268,7 @@ test_setup()
     mkdir -p $BUILD_DIR
 
 
-    _f=$top_srcdir/src/agent/otbr-agent.conf
+    _f=$ABS_SRC/src/agent/otbr-agent.conf
     if [ ! -f $_f ]
     then
 	EXIT_MESSAGE="Missing: $_f"

--- a/tests/meshcop/meshcop
+++ b/tests/meshcop/meshcop
@@ -73,6 +73,8 @@ then
     exit 1
 fi
 
+find $ABS_BLD -type f -print
+
 # What we care about is the AGENT
 #
 # this is the border router agent, it should have been built already

--- a/tests/meshcop/meshcop
+++ b/tests/meshcop/meshcop
@@ -30,7 +30,6 @@
 IS_SUCCESS=false
 
 # Get our starting directory and remember it
-cd $(dirname $0)
 THIS_DIR=`pwd`
 echo "cwd: ${THIS_DIR}"
 echo "top_srcdir: ${top_srcdir}"
@@ -88,7 +87,6 @@ then
     exit 1
 fi
 
-find $ABS_BLD -type f -print
 set +x
 # What we care about is the AGENT
 #

--- a/tests/meshcop/meshcop
+++ b/tests/meshcop/meshcop
@@ -31,7 +31,7 @@
 THIS_DIR=`pwd`
 
 # Assume TRAVIS has set this variable
-if [ x"$TRAVIS" == x"" ]
+if [ x"${TRAVIS}" == x"" ]
 then
     # If not, then set it for us
     # for example you might be debugging

--- a/tests/meshcop/meshcop
+++ b/tests/meshcop/meshcop
@@ -31,14 +31,15 @@
 THIS_DIR=`pwd`
 
 # Assume TRAVIS has set this variable
-if [ x"${TRAVIS}" == x"" ]
+set -x
+if [ -z $TRAVIS ]
 then
     # If not, then set it for us
     # for example you might be debugging
     # or running this script manually
     TRAVIS=false
 fi
-
+set +x
 # get our ABS locations.
 if $TRAVIS
 then

--- a/tests/meshcop/meshcop
+++ b/tests/meshcop/meshcop
@@ -44,6 +44,7 @@ fi
 
 # get our ABS locations.
 set -x
+set -e
 if $TRAVIS
 then
     # TRAVIS NOTE:
@@ -65,8 +66,8 @@ then
     echo "Travis build"
     # This is where the 'dist-check" is performed'
     # this is a source directory
-    ABS_BLD=`${THIS_DIR}/${top_builddir} && pwd`
-    ABS_SRC=`${THIS_DIR}/${top_srcdir} && pwd`
+    ABS_BLD=`cd ${THIS_DIR}/${top_builddir} && pwd`
+    ABS_SRC=`cd ${THIS_DIR}/${top_srcdir} && pwd`
 else
     echo "non-travis build"
     ABS_SRC=`cd ${THIS_DIR}/../.. && pwd`

--- a/tests/meshcop/meshcop
+++ b/tests/meshcop/meshcop
@@ -30,6 +30,7 @@
 IS_SUCCESS=false
 
 # Get our starting directory and remember it
+cd $(dirname $0)
 THIS_DIR=`pwd`
 echo "cwd: ${THIS_DIR}"
 echo "top_srcdir: ${top_srcdir}"
@@ -83,7 +84,7 @@ echo "ABS_BLD=${ABS_BLD}"
 _f=${ABS_SRC}/src/agent/main.cpp
 if [ ! -f $_f ]
 then
-    echo "MISSING: $_f"
+    echo "Missing: $_f"
     exit 1
 fi
 
@@ -455,21 +456,21 @@ leader_start()
 
     if [ ! -x $CLI_EXE ]
     then
-	EXIT_MESSAGE="MISSING cli: $CLI_EXE"
+	EXIT_MESSAGE="Missing cli: $CLI_EXE"
 	echo $EXIT_MESSAGE
 	exit 1
     fi
 
     if [ ! -x $WPANCTL_EXE ]
     then
-	EXIT_MESSAGE="MISSING wpanctl: $WPANCTL_EXE"
+	EXIT_MESSAGE="Missing wpanctl: $WPANCTL_EXE"
 	echo $EXIT_MESSAGE
 	exit 1
     fi
 
     if [ ! -x $WPANTUND_EXE ]
     then
-	EXIT_MESSAGE="MISSING wpantund: $WPANTUND_EXE"
+	EXIT_MESSAGE="Missing wpantund: $WPANTUND_EXE"
 	echo $EXIT_MESSAGE
 	exit 1
     fi

--- a/tests/unit/test_logging.cpp
+++ b/tests/unit/test_logging.cpp
@@ -44,12 +44,12 @@ TEST(Logging, TestLoggingHigherLevel)
 
     sprintf(ident, "otbr-test-%ld", clock());
     otbrLogInit(ident, OTBR_LOG_INFO);
-    otbrLog(OTBR_LOG_DEBUG, "cool");
+    otbrLog(OTBR_LOG_DEBUG, "cool-higher");
     otbrLogDeinit();
     sleep(0);
 
     char cmd[128];
-    sprintf(cmd, "grep '%s.\\+cool' /var/log/syslog", ident);
+    sprintf(cmd, "grep '%s.*cool-higher' /var/log/syslog", ident);
     CHECK(0 != system(cmd));
 }
 
@@ -59,41 +59,58 @@ TEST(Logging, TestLoggingEqualLevel)
 
     sprintf(ident, "otbr-test-%ld", clock());
     otbrLogInit(ident, OTBR_LOG_INFO);
-    otbrLog(OTBR_LOG_INFO, "cool");
+    otbrLog(OTBR_LOG_INFO, "cool-equal");
     otbrLogDeinit();
     sleep(0);
 
     char cmd[128];
-    sprintf(cmd, "grep '%s.\\+cool' /var/log/syslog", ident);
+    sprintf(cmd, "grep '%s.*cool-equal' /var/log/syslog", ident);
+    printf("CMD = %s\n",cmd);
     CHECK(0 == system(cmd));
 }
 
 TEST(Logging, TestLoggingLowerLevel)
 {
     char ident[20];
-
+    char cmd[128];
+    
     sprintf(ident, "otbr-test-%ld", clock());
     otbrLogInit(ident, OTBR_LOG_INFO);
-    otbrLog(OTBR_LOG_WARNING, "cool");
+    otbrLog(OTBR_LOG_WARNING, "cool-lower");
     otbrLogDeinit();
     sleep(0);
 
-    char cmd[128];
-    sprintf(cmd, "grep '%s.\\+cool' /var/log/syslog", ident);
+    sprintf(cmd, "grep '%s.*cool-lower' /var/log/syslog", ident);
     CHECK(0 == system(cmd));
 }
 
 TEST(Logging, TestLoggingDump)
 {
-    char ident[20];
+    char ident[120];
+    char cmd[128];
 
     sprintf(ident, "otbr-test-%ld", clock());
-    otbrLogInit(ident, OTBR_LOG_INFO);
-    otbrDump(OTBR_LOG_INFO, "cool", "cool", 4);
+    otbrLogInit(ident, OTBR_LOG_DEBUG);
+    const char s[] = "one super long string with lots of text";
+    otbrDump(OTBR_LOG_INFO, "foobar", s, sizeof(s));
     otbrLogDeinit();
     sleep(0);
+    
+    /*
+     * Above produces output like this
+     * otbr-test-5976[47088]: foobar: 0000: 6f 6e 65 20 73 75 70 65 72 20 6c 6f 6e 67 20 73
+     * otbr-test-5976[47088]: foobar: 0010: 74 72 69 6e 67 20 77 69 74 68 20 6c 6f 74 73 20
+     * otbr-test-5976[47088]: foobar: 0020: 6f 66 20 74 65 78 74 00
+     */
+    
+    sprintf(cmd, "grep '%s.*: foobar: 0000: 6f 6e 65 20 73 75 70 65 72 20 6c 6f 6e 67 20 73' /var/log/syslog", ident);
+    CHECK(0 == system(cmd));
 
-    char cmd[128];
-    sprintf(cmd, "grep '%s.\\+#4 636f6f6c$' /var/log/syslog", ident);
+
+    sprintf(cmd, "grep '%s.*: foobar: 0010: 74 72 69 6e 67 20 77 69 74 68 20 6c 6f 74 73 20' /var/log/syslog", ident);
+    CHECK(0 == system(cmd));
+
+
+    sprintf(cmd, "grep '%s.*: foobar: 0020: 6f 66 20 74 65 78 74 00' /var/log/syslog", ident);
     CHECK(0 == system(cmd));
 }

--- a/tests/unit/test_logging.cpp
+++ b/tests/unit/test_logging.cpp
@@ -65,7 +65,7 @@ TEST(Logging, TestLoggingEqualLevel)
 
     char cmd[128];
     sprintf(cmd, "grep '%s.*cool-equal' /var/log/syslog", ident);
-    printf("CMD = %s\n",cmd);
+    printf("CMD = %s\n", cmd);
     CHECK(0 == system(cmd));
 }
 
@@ -73,7 +73,7 @@ TEST(Logging, TestLoggingLowerLevel)
 {
     char ident[20];
     char cmd[128];
-    
+
     sprintf(ident, "otbr-test-%ld", clock());
     otbrLogInit(ident, OTBR_LOG_INFO);
     otbrLog(OTBR_LOG_WARNING, "cool-lower");
@@ -95,14 +95,14 @@ TEST(Logging, TestLoggingDump)
     otbrDump(OTBR_LOG_INFO, "foobar", s, sizeof(s));
     otbrLogDeinit();
     sleep(0);
-    
+
     /*
      * Above produces output like this
      * otbr-test-5976[47088]: foobar: 0000: 6f 6e 65 20 73 75 70 65 72 20 6c 6f 6e 67 20 73
      * otbr-test-5976[47088]: foobar: 0010: 74 72 69 6e 67 20 77 69 74 68 20 6c 6f 74 73 20
      * otbr-test-5976[47088]: foobar: 0020: 6f 66 20 74 65 78 74 00
      */
-    
+
     sprintf(cmd, "grep '%s.*: foobar: 0000: 6f 6e 65 20 73 75 70 65 72 20 6c 6f 6e 67 20 73' /var/log/syslog", ident);
     CHECK(0 == system(cmd));
 


### PR DESCRIPTION
Current test app: ${borderrouter}/tests/meshcop/commissioner.cpp - and the associated test script meshcop are very hard coded for a very specific test scenario.

This pull request:

* Removes hard coding of the test app
* Adds features to the test app to calculate for example the PSKc
* And can be used with any target device by adjusting various command line parameters.

General intent is that the commissioner test app can be used from a script to commission *actual* physical hardware via a script in a test farm scenario.

NOTE: A number of bugs/issues where found with the test scripts during this process, they are noted here: https://github.com/openthread/borderrouter/issues/94
