### PR TITLE
[agent] add a space between string literal and macro to meet c++11 standard.

### DIFF
--- a/src/agent/ncp_wpantund.cpp
+++ b/src/agent/ncp_wpantund.cpp
@@ -55,8 +55,8 @@ namespace Ncp {
 /**
  * This string is used to filter the property changed signal from wpantund.
  */
-const char *kDBusMatchPropChanged = "type='signal',interface='"WPANTUND_DBUS_APIv1_INTERFACE "',"
-                                    "member='"WPANTUND_IF_SIGNAL_PROP_CHANGED "'";
+const char *kDBusMatchPropChanged = "type='signal',interface='" WPANTUND_DBUS_APIv1_INTERFACE "',"
+                                    "member='" WPANTUND_IF_SIGNAL_PROP_CHANGED "'";
 
 #define OTBR_AGENT_DBUS_NAME_PREFIX "otbr.agent"
 


### PR DESCRIPTION
Compile OTBR with latest Raspbian Stretch Lite OS image, had one compile error as below:

<img width="772" alt="screen shot 2017-08-24 at 10 37 42 pm" src="https://user-images.githubusercontent.com/19245360/29672193-1f2d62ca-891e-11e7-8a6e-1ecd2d59551d.png">


Add a space between string literal and macro to fix this error.