### PR TITLE
[agent] request event synchronously.

### DIFF
--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -238,11 +238,7 @@ otbrError BorderAgent::Start(void)
 
     mNcp->On(Ncp::kEventPSKc, HandlePSKcChanged, this);
 
-    {
-        const uint8_t *pskc = mNcp->GetPSKc();
-        VerifyOrExit(pskc != NULL, error = OTBR_ERROR_ERRNO);
-        mDtlsServer->SetPSK(pskc, kSizePSKc);
-    }
+    mNcp->RequestEvent(Ncp::kEventPSKc);
 
     {
         const uint8_t *eui64 = mNcp->GetEui64();
@@ -255,7 +251,7 @@ otbrError BorderAgent::Start(void)
 exit:
     if (error != OTBR_ERROR_NONE)
     {
-        otbrLog(OTBR_LOG_ERR, "Failed to start border agent: %d!", error);
+        otbrLog(OTBR_LOG_ERR, "Failed to start border agent: %s!", otbrErrorString(error));
     }
 
     return error;

--- a/src/agent/ncp.hpp
+++ b/src/agent/ncp.hpp
@@ -127,16 +127,6 @@ public:
     virtual void Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet) = 0;
 
     /**
-     * This method retrieves the current PSKc.
-     *
-     * @returns The current PSKc.
-     *
-     * @retval  NULL    Failed to get PSKc, error code set in errno.
-     *
-     */
-    virtual const uint8_t *GetPSKc(void) = 0;
-
-    /**
      * This method retrieves the Eui64.
      *
      * @returns The hardware address.

--- a/src/agent/ncp_wpantund.hpp
+++ b/src/agent/ncp_wpantund.hpp
@@ -125,16 +125,6 @@ public:
     virtual void Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet, const fd_set &aErrorFdSet);
 
     /**
-     * This method retrieves the current PSKc.
-     *
-     * @returns The current PSKc.
-     *
-     * @retval  NULL    Failed to get PSKc, error code set in errno.
-     *
-     */
-    virtual const uint8_t *GetPSKc(void);
-
-    /**
      * This method retrieves the Eui64.
      *
      * @returns The hardware address.
@@ -162,12 +152,13 @@ private:
      */
     typedef std::map<DBusWatch *, bool> WatchMap;
 
-    static DBusHandlerResult HandleProperyChangedSignal(DBusConnection *aConnection, DBusMessage *aMessage,
-                                                        void *aContext);
-    DBusHandlerResult HandleProperyChangedSignal(DBusConnection &aConnection, DBusMessage &aMessage);
+    static DBusHandlerResult HandlePropertyChangedSignal(DBusConnection *aConnection, DBusMessage *aMessage,
+                                                         void *aContext);
+    DBusHandlerResult HandlePropertyChangedSignal(DBusMessage &aMessage);
 
     DBusMessage *RequestProperty(const char *aKey);
     otbrError GetProperty(const char *aKey, uint8_t *aBuffer, size_t &aSize);
+    otbrError ParseEvent(const char *aKey, DBusMessageIter *aIter);
 
     otbrError TmfProxyEnable(dbus_bool_t aEnable);
 


### PR DESCRIPTION
Not changed property values will not be sent if requested asynchronously. This PR changes NCP to request events synchronously so that we don't requiring wpantund start first for certain situations.