### PR TITLE
[docs] READMEs for tools

### DIFF
--- a/tests/meshcop/README.md
+++ b/tests/meshcop/README.md
@@ -1,0 +1,5 @@
+# OTBR Commissioner
+
+`otbr-commissioner` commissions a Thread device from the command line. This tool is used in MeshCop (Mesh Commissioning Protocol) tests during continuous integration. Build and install OpenThread Border Router to use this tool.
+
+See [Tools and Scripts](https://openthread.io/guides/border_router/tools) for more info.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,5 @@
+# PSKc Generator
+
+`pskc` generates a Pre-Shared Key for the Commissioner (PSKc). The PSKc is used to authenticate an external Thread Commissioner to a Thread network. Build and install OpenThread Border Router to use this tool.
+
+See [Tools and Scripts](https://openthread.io/guides/border_router/tools) for more info.


### PR DESCRIPTION
Adding READMEs to call out useful tools and redirect the user to openthread.io.

Wait until the Tools & Scripts page is live on openthread.io before merging.