### PR TITLE
Fix problem with not working scripts after merge Beagle Bone Black platform

### DIFF
--- a/script/_initrc
+++ b/script/_initrc
@@ -95,13 +95,8 @@ without()
 if [ -f /sys/firmware/devicetree/base/model ]
 then
     # Note: 'model' is a binary file with no newline
-    cat /sys/firmware/devicetree/base/model | grep -s "BeagleBone Black" > /dev/null
-    if [ $? -eq 0 ]
-    then
-        PLATFORM=beagleboneblack
-    fi
+    cat /sys/firmware/devicetree/base/model | grep -s "BeagleBone Black" && PLATFORM=beagleboneblack
 fi
-
 
 if test -z "$PLATFORM"; then
     have_or_die lsb_release


### PR DESCRIPTION
This pull request fixes problem with not working scripts on platforms different than BeagleBone Black. The root cause of problem was line: 98 in file `script/_initrc`, which check if there is a string "BeagleBone Black" in the path: `/sys/firmware/devicetree/base/model`. If there was this file present and doesn't contain string "BeagleBone Black" code ended because there was called command `set -e` (few lines above). Command `set -e` causes that script simply ends when gets return code different than 0. So for raspberry pi return code was always equal 1.