### PR TITLE
Introduce ncp_state_notifier to improve Border Router extensibility.

### DIFF
--- a/script/_dhcpv6_pd
+++ b/script/_dhcpv6_pd
@@ -29,8 +29,8 @@
 #   Description:
 #       This script manipulates DHCPv6-PD configuration.
 #
-
-# Currently solution was verified only on raspbian and ubuntu.
+#
+# Currently solution was verified only on raspbian.
 #
 
 if [ $PLATFORM = "ubuntu" ]; then
@@ -47,14 +47,19 @@ WPANTUND_ENV="/etc/default/wpantund"
 DHCPCD_CONF="/etc/dhcpcd.conf"
 DHCPCD_CONF_BACKUP="$DHCPCD_CONF.orig"
 
-DHCPCD_RELOADER="/usr/sbin/dhcpcd_reloader"
-DHCPCD_RELOADER_SERVICE="/etc/systemd/system/dhcpcd_reloader.service"
+NCP_STATE_NOTIFIER="/usr/sbin/ncp_state_notifier"
+NCP_STATE_DISPATCHER="/etc/ncp_state_notifier/dispatcher.d"
+
+NCP_STATE_NOTIFIER_SERVICE_NAME="ncp_state_notifier.service"
+NCP_STATE_NOTIFIER_SERVICE="/etc/systemd/system/${NCP_STATE_NOTIFIER_SERVICE_NAME}"
+
+DHCPCD_RELOADER="${NCP_STATE_DISPATCHER}/dhcpcd_reloader"
 
 without DHCPV6_PD || test $PLATFORM = raspbian || test $PLATFORM = ubuntu || die "DHCPv6-PD is not tested under $PLATFORM."
 
 create_dhcpcd_conf_with_dhcpv6_pd()
 {
-    sudo tee $DHCPCD_CONF << EOF
+    sudo tee ${DHCPCD_CONF} << EOF
 # A sample configuration for dhcpcd.
 # See dhcpcd.conf(5) for details.
 
@@ -100,7 +105,6 @@ denyinterfaces nat*
 noipv6rs
 
 interface $WPANTUND_INTERFACE
-iaid 0
 nodhcp
 nodhcp6
 
@@ -110,27 +114,63 @@ ipv6rs
 ia_na 2 
 ia_pd 3/::/63 $WPANTUND_INTERFACE/1
 
-interface $WLAN_INTERFACE 
+EOF
+
+if [ $PLATFORM = "raspbian" ]; then
+    sudo tee -a ${DHCPCD_CONF} << EOF
+interface $WLAN_INTERFACE
 iaid 4
 ipv6rs
 ia_na 5
 ia_pd 6/::/63 $WPANTUND_INTERFACE/1
-
 EOF
+fi
 }
 
-create_dhcpcd_reloader_script()
+create_ncp_state_notifier_script()
 {
-    sudo tee $DHCPCD_RELOADER << EOF
+    sudo tee ${NCP_STATE_NOTIFIER} << EOF
 #!/bin/sh
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+#   Description:
+#       This script notifies about NCP state changes.
+#
 
 PID=\$\$
-NAME="dhcpcd_reloader"
+NAME="ncp_state_notifier"
 
-echo \${PID} > /tmp/\${NAME}.pid
+DISPATCHER_PATH="${NCP_STATE_DISPATCHER}"
+
+echo \${PID} > "/tmp/\${NAME}.pid"
 
 if [ -z \${IFACE} ]; then
-    IFACE="$WPANTUND_INTERFACE"
+    IFACE=${WPANTUND_INTERFACE}
 fi
 
 WPANTUND_IFACE="com.nestlabs.WPANTunnelDriver"
@@ -138,8 +178,80 @@ WPANTUND_NCP_STATE_PATH="/com/nestlabs/WPANTunnelDriver/\${IFACE}/Properties/NCP
 
 WATCH1="type='signal', interface=\${WPANTUND_IFACE}, path=\${WPANTUND_NCP_STATE_PATH}, member='PropertyChanged'"
 
-reload_dhcpcd_daemon()
+notify_about_state()
 {
+    logger -t "\${NAME}[\${PID}]" "Notifying about change state to: \${1} on the interface: \${2}"
+
+    for SCRIPT in \`find \${DISPATCHER_PATH} -type f\`; do
+        logger -t "\${NAME}[\${PID}]" "Running script: \${SCRIPT}"
+        .\${SCRIPT} \${1} \${2}
+    done
+}
+
+process_output()
+{
+    local NEXT_LINE_IS_STATE=0
+
+    while read -r LINE; do
+        if echo \${LINE} | grep -q "NCP:State"; then
+            NEXT_LINE_IS_STATE=1
+            continue
+        fi
+
+        if [ \${NEXT_LINE_IS_STATE} -eq 1 ]; then
+            NEXT_LINE_IS_STATE=1
+
+            STATE=\`echo \${LINE} | cut -d'"' -f2\`
+            notify_about_state \${STATE} \${IFACE}
+        fi
+    done
+}
+
+dbus-monitor --system "\${WATCH1}" | process_output
+EOF
+}
+
+create_dhcpcd_reloader_script()
+{
+    sudo tee ${DHCPCD_RELOADER} << EOF
+#!/bin/sh
+#
+#  Copyright (c) 2017, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+#   Description:
+#       This script reloads dhcpcd.
+#
+
+PID=\$\$
+NAME="dhcpcd_reloader"
+
+STATE=\$1
+
+if [ \${STATE} = "associated" ]; then
     if systemctl is-active NetworkManager; then
         logger -t "\${NAME}[\${PID}]" "NetworkManager: active"
 
@@ -150,42 +262,30 @@ reload_dhcpcd_daemon()
     fi
 
     if systemctl is-active dhcpcd; then
-        logger -t "\${NAME}[\${PID}]" "dhcpcd: reload daemon"
+        logger -t "\${NAME}[\${PID}]" "dhcpcd: reload"
+
         sudo systemctl reload-daemon
         sudo systemctl force-reload dhcpcd
     fi
-}
-
-process_output()
-{
-    while read -r line; do
-        if echo \${line} | grep -q "associated"; then
-            reload_dhcpcd_daemon
-        fi
-    done
-}
-
-dbus-monitor --system "\${WATCH1}" | process_output
-
+fi
 EOF
 }
 
-create_dhcpcd_reloader_service()
+create_ncp_state_notifier_service()
 {
-    sudo tee $DHCPCD_RELOADER_SERVICE << EOF
+    sudo tee ${NCP_STATE_NOTIFIER_SERVICE} << EOF
 [Unit]
-Description=Daemon reload dhcpcd after change NCP state to associated
+Description=Daemon call scripts on every NCP state change
 After=wpantund.service
-ConditionPathExists=/usr/sbin/dhcpcd_reloader
+ConditionPathExists=${NCP_STATE_NOTIFIER}
 
 [Service]
-ExecStart=/bin/sh /usr/sbin/dhcpcd_reloader
-PIDFile=/tmp/dhcpcd_resolver.pid
+ExecStart=/bin/sh ${NCP_STATE_NOTIFIER}
+PIDFile=/tmp/ncp_state_notifier.pid
 KillMode=control-group
 
 [Install]
 WantedBy=multi-user.target
-
 EOF
 }
 
@@ -199,17 +299,25 @@ dhcpv6_pd_install()
     with DHCPV6_PD || return 0
 
     # Create backup of the default configuration of dhcpcd
-    sudo mv $DHCPCD_CONF $DHCPCD_CONF_BACKUP
+    sudo mv ${DHCPCD_CONF} ${DHCPCD_CONF_BACKUP}
 
     create_dhcpcd_conf_with_dhcpv6_pd
+
+    create_ncp_state_notifier_script
+    sudo chmod +x ${NCP_STATE_NOTIFIER}
+
+    mkdir -p ${NCP_STATE_DISPATCHER}
+
     create_dhcpcd_reloader_script
+    sudo chmod +x ${DHCPCD_RELOADER}
+
     create_wpantund_env_file
 
     if have systemctl; then
-        create_dhcpcd_reloader_service
+        create_ncp_state_notifier_service
 
         sudo systemctl daemon-reload
-
+        
         if systemctl is-active NetworkManager; then
             sudo systemctl restart NetworkManager || die "Unable to restart NetworkManager!"
         fi
@@ -218,8 +326,8 @@ dhcpv6_pd_install()
             sudo systemctl restart dhcpcd || die 'Unable to restart dhcpcd!'
         fi
 
-        sudo systemctl start dhcpcd_reloader.service || die 'Unable to start dhcpcd_reloader!'
-        sudo systemctl enable dhcpcd_reloader.service || die 'Unable to enable dhcpcd_reloader!'
+        sudo systemctl start ${NCP_STATE_NOTIFIER_SERVICE_NAME} || die "Unable to start ${NCP_STATE_NOTIFIER_SERVICE_NAME}!"
+        sudo systemctl enable ${NCP_STATE_NOTIFIER_SERVICE_NAME} || die "Unable to enable ${NCP_STATE_NOTIFIER_SERVICE_NAME}!"
     fi
 }
 
@@ -228,14 +336,17 @@ dhcpv6_pd_uninstall()
     with DHCPV6_PD || return 0
 
     if have systemctl; then
-        sudo systemctl disable dhcpcd_reloader.service || true
-        sudo systemctl stop dhcpcd_reloader.service || true
+        sudo systemctl disable ${NCP_STATE_NOTIFIER_SERVICE_NAME} || true
+        sudo systemctl stop ${NCP_STATE_NOTIFIER_SERVICE_NAME} || true
 
-        sudo rm -rf $DHCPCD_RELOADER_SERVICE || true
+        sudo rm ${NCP_STATE_NOTIFIER_SERVICE} || true
     fi
 
+    sudo rm ${NCP_STATE_NOTIFIER} || true
     sudo rm ${DHCPCD_RELOADER} || true
     sudo rm ${WPANTUND_ENV} || true
+
+    sudo rm -r ${NCP_STATE_DISPATCHER} || true
 
     # Restore backup of the default configuration of dhcpcd
     sudo mv ${DHCPCD_CONF_BACKUP} ${DHCPCD_CONF} || true
@@ -249,8 +360,7 @@ dhcpv6_pd_uninstall()
         fi
 
         if systemctl is-active dhcpcd; then
-            sudo systemctl restart dhcpcd.service || true
+            sudo systemctl restart dhcpcd || true
         fi
     fi
 }
-

--- a/script/_network_manager
+++ b/script/_network_manager
@@ -257,6 +257,10 @@ release_dhcpcd()
 handle_action_up()
 {
     case \${IFNAME} in
+    enp*)
+        enable_accept_ra
+        start_dhcpcd
+        ;;
     eth*)
         enable_accept_ra
         start_dhcpcd
@@ -276,6 +280,9 @@ handle_action_up()
 handle_action_down()
 {
     case \${IFNAME} in
+    enp*)
+        release_dhcpcd
+        ;;
     eth*)
         release_dhcpcd
         ;;
@@ -316,25 +323,26 @@ network_manager_install()
     sudo systemctl daemon-reload
 
     sudo systemctl stop wpa_supplicant || true
-    sudo systemctl disable wpa_supplicant
+    sudo systemctl disable wpa_supplicant || true
 
     sudo systemctl stop dhcpcd || true
-    sudo systemctl disable dhcpcd
+    sudo systemctl disable dhcpcd || true
 
     sudo systemctl daemon-reload
 
-    sudo systemctl start NetworkManager
-    sudo systemctl enable NetworkManager
+    sudo systemctl start NetworkManager || die "Failed to start NetworkManager."
+    sudo systemctl enable NetworkManager || die "Failed to enable NetworkManager."
 
-    create_ap_helper_script
-    sudo chmod a+x ${AP_HELPER_SCRIPT}
+    # Create AP connection only on raspbian platform.
+    if [ $PLATFORM = raspbian ]; then
+        create_ap_helper_script
+        sudo chmod a+x ${AP_HELPER_SCRIPT}
+
+        create_ap_connection
+    fi
 
     create_dhcpv6_helper_script
     sudo chmod a+x ${DHCPV6_HELPER_SCRIPT}
-
-    if [ $PLATFORM = raspbian ]; then
-        create_ap_connection
-    fi
 
     create_eth_connection
 
@@ -343,11 +351,11 @@ network_manager_install()
 
     sleep 15
 
-    sudo nmcli c up ${ETH_CONN}
-
     if [ $PLATFORM = raspbian ]; then
         sudo nmcli c up ${AP_CONN}
     fi
+
+    sudo nmcli c up ${ETH_CONN}
 }
 
 network_manager_uninstall()
@@ -380,9 +388,9 @@ network_manager_uninstall()
 
     sudo systemctl daemon-reload
 
-    sudo systemctl start dhcpcd
-    sudo systemctl enable dhcpcd
+    sudo systemctl start dhcpcd || true
+    sudo systemctl enable dhcpcd || true
 
-    sudo systemctl start wpa_supplicant
-    sudo systemctl enable wpa_supplicant
+    sudo systemctl start wpa_supplicant || true
+    sudo systemctl enable wpa_supplicant || true
 }

--- a/script/setup
+++ b/script/setup
@@ -59,9 +59,9 @@ main()
     ipforward_install
     nat64_install
     dns64_install
-    wpantund_install
-    dhcpv6_pd_install
     network_manager_install
+    wpantund_install
+    dhcpv6_pd_install    
     otbr_install
     . $AFTER_HOOK
 }


### PR DESCRIPTION
This pull request adds "ncp_state_notifier" to be able to react on NCP state changes. After add this change it possible to e.g. reload dhcpcd when NCP change it state to associated.