### PR TITLE
Modify configure.ac to allow cross-compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -304,10 +304,6 @@ AC_MSG_NOTICE([checking required package dependencies])
 
 # NL_WITH_PACKAGE(...)
 
-# Check if the build host has pkg-config
-
-AC_PATH_PROG([PKG_CONFIG],[pkg-config])
-
 # Check if ctags is present.
 
 AC_MSG_CHECKING([checking if Exuberant Ctags is available])


### PR DESCRIPTION
Checking if building computer has `pkg-config` before getting `libdbus` data leads to setting some environment variables to _build version_ of `pkg-config` instead of _target host version_ of `pkg-config`. It prevents `configure` from finding `libdbus`