### PR TITLE
[codecov] enable code coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "third_party/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ cache:
 
 before_install: .travis/before_install.sh
 script: .travis/script.sh
+after_success: bash <(curl -s https://codecov.io/bash)
+
 matrix:
   include:
     - env: BUILD_TARGET="pretty-check"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
     - env: BUILD_TARGET="posix-check" VERBOSE=1
       compiler: gcc
       os: linux
-    - env: BUILD_TARGET="posix-check" VERBOSE=1 WITH_MDNS=mdnssd
+    - env: BUILD_TARGET="posix-check" VERBOSE=1 WITH_MDNS=mDNSResponder
       compiler: gcc
       os: linux
     - env: BUILD_TARGET="raspbian-gcc" VERBOSE=1 IMAGE_NAME=2017-04-10-raspbian-jessie-lite IMAGE_URL=http://director.downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2017-04-10/2017-04-10-raspbian-jessie-lite.zip

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -49,7 +49,7 @@ posix-check)
     export LDFLAGS="$LDFLAGS -L$TOOLS_HOME/usr/lib"
     ./bootstrap
     ./configure
-    distcleancheck_listfiles="find . -type f \\( -name '*.gcda' -o -name '*.gcno' \\) -exec mv {} '$(pwd)/{}' \\;;find . -type f"
+    distcleancheck_listfiles="find . -type f \\( -name '*.gcda' -o -name '*.gcno' \\) -exec mv '{}' '$(pwd)/{}' \\;;find . -type f"
     if [ "$WITH_MDNS" = 'mDNSResponder' ]; then
         sudo service avahi-daemon stop
         sudo mdnsd

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -49,7 +49,7 @@ posix-check)
     export LDFLAGS="$LDFLAGS -L$TOOLS_HOME/usr/lib"
     ./bootstrap
     ./configure
-    distcleancheck_listfiles='find . -type f ! -name "*.gcda" ! -name "*.gcno"'
+    distcleancheck_listfiles="find . -type f \\( -name '*.gcda' -o -name '*.gcno' \\) -exec mv {} '$(pwd)/{}' \\;;find . -type f"
     if [ "$WITH_MDNS" = 'mDNSResponder' ]; then
         sudo service avahi-daemon stop
         sudo mdnsd

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -47,13 +47,15 @@ pretty-check)
 posix-check)
     export CPPFLAGS="$CFLAGS -I$TOOLS_HOME/usr/include"
     export LDFLAGS="$LDFLAGS -L$TOOLS_HOME/usr/lib"
-    ./bootstrap || die
+    ./bootstrap
+    ./configure
+    distcleancheck_listfiles='find . -type f ! -name "*.gcda" ! -name "*.gcno"'
     if [ "$WITH_MDNS" = 'mDNSResponder' ]; then
         sudo service avahi-daemon stop
         sudo mdnsd
-        ./configure && make distcheck DISTCHECK_CONFIGURE_FLAGS='--with-mdns=mDNSResponder'
+        make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-coverage --with-mdns=mDNSResponder' distcleancheck_listfiles="${distcleancheck_listfiles}"
     else
-        ./configure && make distcheck
+        make distcheck DISTCHECK_CONFIGURE_FLAGS='--enable-coverage' distcleancheck_listfiles="${distcleancheck_listfiles}"
     fi
     ;;
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ More information about Thread can be found at [threadgroup.org](http://threadgro
 
 [otbr-travis]: https://travis-ci.org/openthread/borderrouter
 [otbr-travis-svg]: https://travis-ci.org/openthread/borderrouter.svg?branch=master
-[otbr-codecov]: https://codecov.io/gh/bukepo/borderrouter
-[otbr-codecov-svg]: https://codecov.io/gh/bukepo/borderrouter/branch/codecov/graph/badge.svg
+[otbr-codecov]: https://codecov.io/gh/openthread/borderrouter
+[otbr-codecov-svg]: https://codecov.io/gh/openthread/borderrouter/branch/master/graph/badge.svg
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status][ot-travis-svg]][ot-travis]
+[![Build Status][otbr-travis-svg]][otbr-travis]
+[![Coverage Status][otbr-codecov-svg]][otbr-codecov]
 
 ---
 
@@ -22,8 +23,10 @@ OpenThread's implementation of a Border Router is called OpenThread Border Route
 
 More information about Thread can be found at [threadgroup.org](http://threadgroup.org/). Thread is a registered trademark of the Thread Group, Inc.
 
-[ot-travis]: https://travis-ci.org/openthread/borderrouter
-[ot-travis-svg]: https://travis-ci.org/openthread/borderrouter.svg?branch=master
+[otbr-travis]: https://travis-ci.org/openthread/borderrouter
+[otbr-travis-svg]: https://travis-ci.org/openthread/borderrouter.svg?branch=master
+[otbr-codecov]: https://codecov.io/gh/bukepo/borderrouter
+[otbr-codecov-svg]: https://codecov.io/gh/bukepo/borderrouter/branch/codecov/graph/badge.svg
 
 ## Getting started
 

--- a/configure.ac
+++ b/configure.ac
@@ -416,7 +416,7 @@ fi
 # Add any code coverage CPPFLAGS and LDFLAGS
 
 CPPFLAGS="${CPPFLAGS} ${NL_COVERAGE_CPPFLAGS}"
-LDFLAGS="${LDFLAGS} ${NL_COVERAGE_LDFLAGS}"
+LIBS="${LIBS} ${NL_COVERAGE_LIBS}"
 
 # At this point, we can restore the compiler flags to whatever the
 # user passed in, now that we're clear of an -Werror issues by

--- a/tests/meshcop/Makefile.am
+++ b/tests/meshcop/Makefile.am
@@ -71,6 +71,9 @@ dist_check_SCRIPTS                                    = \
 
 TESTS_ENVIRONMENT                                     = \
     export                                              \
+    CFLAGS=''                                           \
+    CPPFLAGS=''                                         \
+    LDFLAGS=''                                          \
     MAKE=$(MAKE)                                        \
     top_builddir='$(top_builddir)'                      \
     top_srcdir='$(top_srcdir)'                          \


### PR DESCRIPTION
* added SIGTERM handler to allow binaries exit elegantly so that `.gcda` files will be generated.
* enhanced the existing distcheck so that no specific check is needed to generate coverage data.