### PR TITLE
[mdns] fix processing mdnssd

### DIFF
--- a/src/agent/border_agent.cpp
+++ b/src/agent/border_agent.cpp
@@ -54,8 +54,8 @@ namespace ot {
 
 namespace BorderRouter {
 
-static const char   kBorderAgentServiceType[] = "_meshcop._udp"; ///< Border agent service type of mDNS
-static const size_t kMaxSizeOfPacket          = 1500;            ///< Max size of packet in bytes.
+static const char   kBorderAgentServiceType[] = "_meshcop._udp."; ///< Border agent service type of mDNS
+static const size_t kMaxSizeOfPacket          = 1500;             ///< Max size of packet in bytes.
 
 /**
  * Locators
@@ -205,9 +205,9 @@ exit:
 
 void BorderAgent::PublishService(void)
 {
-    assert(mNetworkName[0] != '\0');
-
     char xpanid[sizeof(mExtPanId) * 2 + 1];
+
+    assert(mNetworkName[0] != '\0');
     Utils::Bytes2Hex(mExtPanId, sizeof(mExtPanId), xpanid);
     mPublisher->PublishService(kBorderAgentUdpPort, mNetworkName, kBorderAgentServiceType, "nn", mNetworkName, "xp",
                                xpanid, NULL);

--- a/src/agent/mdns_avahi.cpp
+++ b/src/agent/mdns_avahi.cpp
@@ -315,34 +315,16 @@ PublisherAvahi::PublisherAvahi(int          aProtocol,
     , mGroup(NULL)
     , mProtocol(aProtocol == AF_INET6 ? AVAHI_PROTO_INET6
                                       : aProtocol == AF_INET ? AVAHI_PROTO_INET : AVAHI_PROTO_UNSPEC)
-    , mHost(NULL)
-    , mDomain(NULL)
+    , mHost(aHost)
+    , mDomain(aDomain)
     , mState(kStateIdle)
     , mStateHandler(aHandler)
     , mContext(aContext)
 {
-    if (aHost)
-    {
-        mHost = strndup(aHost, kMaxSizeOfHost);
-    }
-
-    if (aDomain)
-    {
-        mDomain = strndup(aDomain, kMaxSizeOfDomain);
-    }
 }
 
 PublisherAvahi::~PublisherAvahi(void)
 {
-    if (mHost)
-    {
-        free(mHost);
-    }
-
-    if (mDomain)
-    {
-        free(mDomain);
-    }
 }
 
 otbrError PublisherAvahi::Start(void)

--- a/src/agent/mdns_avahi.hpp
+++ b/src/agent/mdns_avahi.hpp
@@ -301,8 +301,8 @@ private:
     AvahiEntryGroup *mGroup;
     Poller           mPoller;
     int              mProtocol;
-    char *           mHost;
-    char *           mDomain;
+    const char *     mHost;
+    const char *     mDomain;
     State            mState;
     StateHandler     mStateHandler;
     void *           mContext;

--- a/src/agent/mdns_mdnssd.hpp
+++ b/src/agent/mdns_mdnssd.hpp
@@ -132,6 +132,9 @@ public:
     void UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, fd_set &aErrorFdSet, int &aMaxFd, timeval &aTimeout);
 
 private:
+    void DiscardService(const char *aName, const char *aType, DNSServiceRef aServiceRef);
+    void RecordService(const char *aName, const char *aType, DNSServiceRef aServiceRef);
+
     static void HandleServiceRegisterResult(DNSServiceRef         aService,
                                             const DNSServiceFlags aFlags,
                                             DNSServiceErrorType   aError,
@@ -153,21 +156,22 @@ private:
         kMaxSizeOfHost        = 128,
         kMaxSizeOfDomain      = kDNSServiceMaxDomainName,
         kMaxSizeOfServiceType = 64,
+        kMaxTextRecordSize    = 255,
     };
 
     struct Service
     {
         char          mName[kMaxSizeOfServiceName];
         char          mType[kMaxSizeOfServiceType];
-        DNSServiceRef mClient;
+        DNSServiceRef mService;
     };
 
     typedef std::vector<Service> Services;
 
     Services     mServices;
     int          mProtocol;
-    char *       mHost;
-    char *       mDomain;
+    const char * mHost;
+    const char * mDomain;
     State        mState;
     StateHandler mStateHandler;
     void *       mContext;

--- a/tests/mdns/main.cpp
+++ b/tests/mdns/main.cpp
@@ -83,7 +83,7 @@ void PublishSingleService(void *aContext, Mdns::State aState)
 
     if (aState == Mdns::kStateReady)
     {
-        assert(OTBR_ERROR_NONE == sContext.mPublisher->PublishService(12345, "SingleService", "_meshcop._udp", "nn",
+        assert(OTBR_ERROR_NONE == sContext.mPublisher->PublishService(12345, "SingleService", "_meshcop._udp.", "nn",
                                                                       "cool", "xp", "1122334455667788", NULL));
     }
 }
@@ -94,9 +94,9 @@ void PublishMultipleServices(void *aContext, Mdns::State aState)
 
     if (aState == Mdns::kStateReady)
     {
-        assert(OTBR_ERROR_NONE == sContext.mPublisher->PublishService(12345, "MultipleService1", "_meshcop._udp", "nn",
+        assert(OTBR_ERROR_NONE == sContext.mPublisher->PublishService(12345, "MultipleService1", "_meshcop._udp.", "nn",
                                                                       "cool1", "xp", "1122334455667788", NULL));
-        assert(OTBR_ERROR_NONE == sContext.mPublisher->PublishService(12346, "MultipleService2", "_meshcop._udp", "nn",
+        assert(OTBR_ERROR_NONE == sContext.mPublisher->PublishService(12346, "MultipleService2", "_meshcop._udp.", "nn",
                                                                       "cool2", "xp", "1122334455667788", NULL));
     }
 }
@@ -109,13 +109,15 @@ void PublishUpdateServices(void *aContext, Mdns::State aState)
     {
         if (!sContext.mUpdate)
         {
-            assert(OTBR_ERROR_NONE == sContext.mPublisher->PublishService(12345, "UpdateService", "_meshcop._udp", "nn",
-                                                                          "cool", "xp", "1122334455667788", NULL));
+            assert(OTBR_ERROR_NONE == sContext.mPublisher->PublishService(12345, "UpdateService", "_meshcop._udp.",
+                                                                          "nn", "cool", "xp", "1122334455667788",
+                                                                          NULL));
         }
         else
         {
-            assert(OTBR_ERROR_NONE == sContext.mPublisher->PublishService(12345, "UpdateService", "_meshcop._udp", "nn",
-                                                                          "coolcool", "xp", "8877665544332211", NULL));
+            assert(OTBR_ERROR_NONE == sContext.mPublisher->PublishService(12345, "UpdateService", "_meshcop._udp.",
+                                                                          "nn", "coolcool", "xp", "8877665544332211",
+                                                                          NULL));
         }
     }
 }

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -36,8 +36,13 @@ unittest_SOURCES           = \
     test_event_emitter.cpp   \
     test_pskc.cpp            \
     test_logging.cpp         \
+    $(NULL)
+
+if OTBR_ENABLE_MDNS_MDNSSD
+unittest_SOURCES          += \
     test_mdns_mdnssd.cpp     \
     $(NULL)
+endif
 
 unittest_CPPFLAGS                                             = \
     -I$(top_srcdir)/src                                         \

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -36,6 +36,7 @@ unittest_SOURCES           = \
     test_event_emitter.cpp   \
     test_pskc.cpp            \
     test_logging.cpp         \
+    test_mdns_mdnssd.cpp     \
     $(NULL)
 
 unittest_CPPFLAGS                                             = \

--- a/tests/unit/test_mdns_mdnssd.cpp
+++ b/tests/unit/test_mdns_mdnssd.cpp
@@ -1,0 +1,69 @@
+/*
+ *    Copyright (c) 2018, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <CppUTest/TestHarness.h>
+
+#include "agent/mdns_mdnssd.cpp"
+
+TEST_GROUP(MdnsSd){};
+
+TEST(MdnsSd, TestDNSErrorToString)
+{
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_NoError));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_Unknown));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_NoSuchName));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_NoMemory));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_BadParam));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_BadReference));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_BadState));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_BadFlags));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_Unsupported));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_NotInitialized));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_AlreadyRegistered));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_NameConflict));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_Invalid));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_Firewall));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_Incompatible));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_BadInterfaceIndex));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_Refused));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_NoSuchRecord));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_NoAuth));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_NoSuchKey));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_NATTraversal));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_DoubleNAT));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_BadTime));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_BadSig));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_BadKey));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_Transient));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_ServiceNotRunning));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_NATPortMappingUnsupported));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_NATPortMappingDisabled));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_NoRouter));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_PollingMode));
+    CHECK(NULL != ot::BorderRouter::Mdns::DNSErrorToString(kDNSServiceErr_Timeout));
+}


### PR DESCRIPTION
From the codecov report, some methods supposed to be called were not called at all. This PR

* fixed this issue by adding service once the register call is successfully returned.
* added a `.` at the end of mdns service type, which will be added by mDNSResponder.