### PR TITLE
[libc] do not use glibc-internal header sys/cdefs.h

### DIFF
--- a/third_party/wpantund/repo/src/util/string-utils.h
+++ b/third_party/wpantund/repo/src/util/string-utils.h
@@ -28,14 +28,16 @@
 #include <stdint.h>
 #include <string.h>
 #include <stdbool.h>
-#include <sys/cdefs.h>
 
 #define strcaseequal(x, y)   (strcasecmp(x, y) == 0)
 #define strncaseequal(x, y, n)   (strncasecmp(x, y, n) == 0)
 #define strequal(x, y)   (strcmp(x, y) == 0)
 #define strnequal(x, y, n)   (strncmp(x, y, n) == 0)
 
-__BEGIN_DECLS
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 extern void memcpyrev(void* dest, const void *src, size_t len);
 extern int memcmprev(const void* dest, const void *src, size_t len);
 extern void reverse_bytes(uint8_t *bytes, size_t count);
@@ -66,6 +68,8 @@ uint32_t strtomask_uint32(const char* in_string);
 
 extern bool strtobool(const char* string);
 
-__END_DECLS
+#if defined(__cplusplus)
+}
+#endif
 
 #endif

--- a/third_party/wpantund/repo/src/wpantund/wpan-error.h
+++ b/third_party/wpantund/repo/src/wpantund/wpan-error.h
@@ -20,7 +20,9 @@
 #define wpantund_wpan_error_h
 #include <stddef.h>
 
-__BEGIN_DECLS
+#if defined(__cplusplus)
+extern "C" {
+#endif
 
 typedef enum {
 	kWPANTUNDStatus_Ok                            = 0,
@@ -75,6 +77,8 @@ typedef enum {
 
 extern const char* wpantund_status_to_cstr(int status);
 
-__END_DECLS
+#if defined(__cplusplus)
+}
+#endif
 
 #endif

--- a/third_party/wpantund/repo/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/wpantund/repo/third_party/openthread/src/ncp/spinel.h
@@ -51,16 +51,6 @@
 #define SPINEL_API_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
 #endif // ifdef __GNUC__
 
-#if !defined(__BEGIN_DECLS) || !defined(__END_DECLS)
-#if defined(__cplusplus)
-#define __BEGIN_DECLS extern "C" {
-#define __END_DECLS }
-#else // if defined(__cplusplus)
-#define __BEGIN_DECLS
-#define __END_DECLS
-#endif // else defined(__cplusplus)
-#endif // if !defined(__BEGIN_DECLS) || !defined(__END_DECLS)
-
 #endif // ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 #ifndef SPINEL_API_EXTERN
@@ -105,7 +95,9 @@
 
 // ----------------------------------------------------------------------------
 
-__BEGIN_DECLS
+#if defined(__cplusplus)
+extern "C" {
+#endif
 
 typedef enum {
     SPINEL_STATUS_OK      = 0, ///< Operation has completed successfully.
@@ -2561,6 +2553,8 @@ SPINEL_API_EXTERN const char *spinel_capability_to_cstr(unsigned int capability)
 
 // ----------------------------------------------------------------------------
 
-__END_DECLS
+#if defined(__cplusplus)
+}
+#endif
 
 #endif /* defined(SPINEL_HEADER_INCLUDED) */


### PR DESCRIPTION
The `sys/cdefs.h` is an internal header of `glibc` and is not meant to
be used by user code.  The macros needed from it can be trivially
implemented where required, relying on this header being present
excludes the OpenThread Border Router from being used on systems where
`glibc` is not the used C library (e.g. OpenWRT, where `uclibc` or
`musl` is standard).

https://wiki.musl-libc.org/faq.html#Q:-When-compiling-something-against-musl,-I-get-error-messages-about-%3Ccode%3Esys/cdefs.h%3C/code%3E