### PR TITLE
[bootstrap] use iputils-ping instead of inetutils-ping

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -38,7 +38,7 @@ install_packages_apt()
     sudo apt-get install -y \
                          wget \
                          iproute2 \
-                         inetutils-ping \
+                         iputils-ping \
                          apt-utils
     sudo apt-get install -y build-essential libtool git
 


### PR DESCRIPTION
*ping6* from `iputils-ping` supports `-I` argument.