### PR TITLE
[systemd] fix unit file installation path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -377,8 +377,6 @@ else
 fi
 AC_SUBST(DBUS_DATADIR)
 
-AM_CONDITIONAL([OTBR_HAS_SYSTEMCTL], [test -x "$(command -v systemctl)"])
-
 #
 # Check for headers
 #
@@ -425,6 +423,14 @@ LIBS="${LIBS} ${NL_COVERAGE_LIBS}"
 # transforming -Wno-error back to -Werror.
 
 NL_RESTORE_WERROR
+
+AC_ARG_WITH([systemdsystemunitdir],
+            AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Path to install systemd unit files.]),
+            [], [with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])
+if test -n "${with_systemdsystemunitdir}"; then
+  AC_SUBST([systemdsystemunitdir], [${with_systemdsystemunitdir}])
+fi
+AM_CONDITIONAL(HAVE_SYSTEMD, [test -n "${with_systemdsystemunitdir}"])
 
 #
 # Identify the various makefiles and auto-generated files for the package

--- a/src/agent/Makefile.am
+++ b/src/agent/Makefile.am
@@ -138,9 +138,8 @@ EXTRA_DIST                = \
 dbusconfdir = $(DBUS_CONFDIR)
 dbusconf_DATA = otbr-agent.conf
 
-if OTBR_HAS_SYSTEMCTL
-systemddir=$(sysconfdir)/systemd/system
-systemd_DATA                        = \
+if HAVE_SYSTEMD
+systemdsystemunit_DATA              = \
     otbr-agent.service                \
     $(NULL)
 endif
@@ -151,7 +150,7 @@ defaultdir=$(sysconfdir)/default
 
 install-data-local: $(DESTDIR)$(defaultdir)/otbr-agent $(DESTDIR)$(initddir)/otbr-agent
 
-if OTBR_HAS_SYSTEMCTL
+if HAVE_SYSTEMD
 uninstall-local:
 	-rm $(DESTDIR)$(defaultdir)/otbr-agent
 else
@@ -165,7 +164,7 @@ $(DESTDIR)$(defaultdir)/otbr-agent: otbr-agent.default
 	test -d $(DESTDIR)$(defaultdir) || mkdir -p $(DESTDIR)$(defaultdir)
 	$(INSTALL_DATA) $(srcdir)/otbr-agent.default $(DESTDIR)$(defaultdir)/otbr-agent
 
-if OTBR_HAS_SYSTEMCTL
+if HAVE_SYSTEMD
 $(DESTDIR)$(initddir)/otbr-agent: ;
 else
 $(DESTDIR)$(initddir)/otbr-agent: otbr-agent.init
@@ -173,9 +172,9 @@ $(DESTDIR)$(initddir)/otbr-agent: otbr-agent.init
 	$(INSTALL) -m 755 ./otbr-agent.init $(DESTDIR)$(initddir)/otbr-agent
 endif
 
-if OTBR_HAS_SYSTEMCTL
-.PHONY: $(systemd_DATA)
-$(systemd_DATA): %: %.in
+if HAVE_SYSTEMD
+.PHONY: $(systemdsystemunit_DATA)
+$(systemdsystemunit_DATA): %: %.in
 	$(SED)                                  \
 	-e 's,[@]sbindir[@],$(sbindir),g'       \
 	-e 's,[@]sysconfdir[@],$(sysconfdir),g' \

--- a/src/web/Makefile.am
+++ b/src/web/Makefile.am
@@ -151,15 +151,13 @@ EXTRA_DIST                                                     = \
     otbr-web.init.in                                             \
     $(NULL)
 
-if OTBR_HAS_SYSTEMCTL
-
-systemddir=$(sysconfdir)/systemd/system
-systemd_DATA                        = \
+if HAVE_SYSTEMD
+systemdsystemunit_DATA              = \
     otbr-web.service                  \
     $(NULL)
 
-.PHONY: $(systemd_DATA)
-$(systemd_DATA): %: %.in
+.PHONY: $(systemdsystemunit_DATA)
+$(systemdsystemunit_DATA): %: %.in
 	$(SED)                                  \
 	-e 's,[@]sbindir[@],$(sbindir),g'       \
 	-e 's,[@]sysconfdir[@],$(sysconfdir),g' \

--- a/third_party/wpantund/Makefile.am
+++ b/third_party/wpantund/Makefile.am
@@ -72,15 +72,13 @@ noinst_HEADERS                                     = \
     repo/third_party/openthread/src/ncp/spinel.h     \
     $(NULL)
 
-if OTBR_HAS_SYSTEMCTL
-
-systemddir=$(sysconfdir)/systemd/system
-systemd_DATA                        = \
+if HAVE_SYSTEMD
+systemdsystemunit_DATA              = \
     wpantund.service                  \
     $(NULL)
 
-.PHONY: $(systemd_DATA)
-$(systemd_DATA): %: %.in
+.PHONY: $(systemdsystemunit_DATA)
+$(systemdsystemunit_DATA): %: %.in
 	$(SED)                                  \
 	-e 's,[@]sbindir[@],$(sbindir),g'       \
 	-e 's,[@]sysconfdir[@],$(sysconfdir),g' \


### PR DESCRIPTION
fixes #207 . Unit files of systemd should be install in `/lib/systemd/system`, which could be get from `pkg-config`