### PR TITLE
[border-agent] ncp_wpatund.cpp: Fix off-by-one strncpy

### DIFF
--- a/src/agent/ncp_wpantund.cpp
+++ b/src/agent/ncp_wpantund.cpp
@@ -225,7 +225,7 @@ ControllerWpantund::ControllerWpantund(const char *aInterfaceName)
     : mDBus(NULL)
 {
     mInterfaceDBusName[0] = '\0';
-    strncpy(mInterfaceName, aInterfaceName, sizeof(mInterfaceName));
+    strncpy(mInterfaceName, aInterfaceName, sizeof(mInterfaceName) - 1);
 }
 
 otbrError ControllerWpantund::UpdateInterfaceDBusPath()


### PR DESCRIPTION
Compiling under alpine:3.9 produces this error:

ncp_wpantund.cpp: In constructor 'ot::BorderRouter::Ncp::ControllerWpantund::ControllerWpantund(const char*)':
ncp_wpantund.cpp:219:12: error: 'char* strncpy(char*, const char*, size_t)' specified bound 16 equals destination size [-Werror=stringop-truncation]
     strncpy(mInterfaceName, aInterfaceName, sizeof(mInterfaceName));
     ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make[3]: *** [Makefile:719: libotbr_agent_la-ncp_wpantund.lo] Error 1
make[2]: *** [Makefile:448: all-recursive] Error 1
make[1]: *** [Makefile:571: all-recursive] Error 1
make: *** [Makefile:497: all] Error 2

IFNAMSIZ is the size required including the NULL byte, so I think the
strncpy needs to be size-1.

Signed-off-by: Andy Doan <andy@foundries.io>