### PR TITLE
[commissioner] ensure close notify on close

### DIFF
--- a/src/commissioner/main.cpp
+++ b/src/commissioner/main.cpp
@@ -61,6 +61,7 @@ int main(int argc, char **argv)
 
     otbrLogInit("Commissioner", args.mDebugLevel);
     signal(SIGTERM, HandleSignal);
+    signal(SIGINT, HandleSignal);
 
     srand(time(0));
 


### PR DESCRIPTION
A quick fix to #254 when user use Ctrl^C to quit the first commissioner. For longer term, I think it makes sense to add an option that the commissioner quit on joiner session ends.